### PR TITLE
Allow early hook for monkey patching hod_main

### DIFF
--- a/bin/hod_main.py
+++ b/bin/hod_main.py
@@ -28,11 +28,20 @@ Main hanythingondemand script, should be invoked in a job
 @author: Stijn De Weirdt (Universiteit Gent)
 @author: Ewan Higgs (Universiteit Gent)
 """
+import os
 from hod.config.hodoption import HodOption
 from hod.hodproc import Slave, HadoopMaster
 from hod.mpiservice import MASTERRANK
 
 from mpi4py import MPI
+
+# allow early hook to make quick modifications
+# while reworking the code is in progress
+monkeypatch_variable = 'HOD_MONKEYPATCH_HOOK'
+if monkeypatch_variable in os.environ:
+    fn = os.environ[monkeypatch_variable]
+    if os.path.isfile(fn):
+        execfile(fn)
 
 options = HodOption()
 


### PR DESCRIPTION
Clearly to be removed at later stage, but can provide easy access to customisations for now.
