### PR TITLE
Fix previous PR as a call to autogen was dropped in some dodgy rebasing.

### DIFF
--- a/etc/hod/Hadoop-2.3.0-cdh5.0.0/hod.conf
+++ b/etc/hod/Hadoop-2.3.0-cdh5.0.0/hod.conf
@@ -8,6 +8,8 @@ modules=Hadoop/2.3.0-cdh5.0.0
 master_env=HADOOP_HOME,EBROOTHADOOP,JAVA_HOME
 services=resourcemanager.conf,nodemanager.conf,screen.conf
 config_writer=hod.config.writer.hadoop_xml
-workdir=/tmp
+# Point the workdir to a path on the parallel file system using the command
+# line named argument: --config-workdir=...
+#workdir=
 autogen=hadoop
 directories=$localworkdir/dfs/name,$localworkdir/dfs/data

--- a/hod/hodproc.py
+++ b/hod/hodproc.py
@@ -107,10 +107,10 @@ class ConfiguredMaster(MpiService):
         self.tasks = []
         m_config = _load_manifest_config(self.options.options.config_config,
                 self.options.options.config_workdir)
+        m_config.autogen_configs()
 
         resolver = _setup_template_resolver(m_config, master_template_args)
         _setup_config_paths(m_config, resolver)
-
 
         master_env = dict([(v, os.getenv(v)) for v in m_config.master_env])
         self.log.debug('MasterEnv is: %s', env2str(master_env))
@@ -142,4 +142,6 @@ class ConfiguredSlave(MpiService):
         """
         m_config = _load_manifest_config(self.options.options.config_config,
                 self.options.options.config_workdir)
-        _setup_template_resolver(m_config, master_template_args)
+        m_config.autogen_configs()
+        resolver = _setup_template_resolver(m_config, master_template_args)
+        _setup_config_paths(m_config, resolver)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def find_files(*dirs):
 
 PACKAGE = {
     'name': 'hanythingondemand',
-    'version': '2.2.0',
+    'version': '2.2.1',
     'author': ['stijn.deweirdt@ugent.be', 'jens.timmerman@ugent.be', 'ewan.higgs@ugent.be'],
     'maintainer': ['stijn.deweirdt@ugent.be', 'jens.timmerman@ugent.be', 'ewan.higgs@ugent.be'],
     'license': "GPL v2",


### PR DESCRIPTION
I plucked the wrong side of a rebase and wasn't calling the autogen. Found this in release testing.

Added a few more unit tests to make sure this doesn't regress again.

Bumped release version in `setup.py` to `2.2.1`.