### PR TITLE
Remove hwloc-bind, fix autogen overrides, and set `yarn.nodemanager.hostname`

### DIFF
--- a/etc/hod/Hadoop-2.3.0-cdh5.0.0/nodemanager.conf
+++ b/etc/hod/Hadoop-2.3.0-cdh5.0.0/nodemanager.conf
@@ -10,7 +10,7 @@ ExecStart=$$EBROOTHADOOP/sbin/yarn-daemon.sh start nodemanager
 ExecStop=$$EBROOTHADOOP/sbin/yarn-daemon.sh stop nodemanager
 
 [Environment]
-YARN_NICENESS=1 /usr/bin/ionice -c2 -n0 /usr/bin/hwloc-bind socket:0
+YARN_NICENESS=1 /usr/bin/ionice -c2 -n0
 HADOOP_CONF_DIR=$localworkdir/conf
 YARN_LOG_DIR=$localworkdir/log
 YARN_PID_DIR=$localworkdir/pid

--- a/etc/hod/Hadoop-2.5.0-cdh5.3.1-gpfs/nodemanager.conf
+++ b/etc/hod/Hadoop-2.5.0-cdh5.3.1-gpfs/nodemanager.conf
@@ -11,7 +11,7 @@ ExecStop=$$EBROOTHADOOP/sbin/yarn-daemon.sh stop nodemanager
 
 [Environment]
 HADOOP_OPTS=-Dhost.name=$dataname -Djava.net.preferIPv4Stack=true
-YARN_NICENESS=1 /usr/bin/ionice -c2 -n0 /usr/bin/hwloc-bind socket:0
+YARN_NICENESS=1 /usr/bin/ionice -c2 -n0
 HADOOP_CONF_DIR=$localworkdir/conf
 YARN_LOG_DIR=$localworkdir/log
 YARN_PID_DIR=$localworkdir/pid

--- a/etc/hod/Hadoop-on-lustre2/nodemanager.conf
+++ b/etc/hod/Hadoop-on-lustre2/nodemanager.conf
@@ -9,7 +9,7 @@ ExecStart=$$EBROOTHADOOP/sbin/yarn-daemon.sh start nodemanager
 ExecStop=$$EBROOTHADOOP/sbin/yarn-daemon.sh stop nodemanager
 
 [Environment]
-YARN_NICENESS=1 /usr/bin/ionice -c2 -n0 /usr/bin/hwloc-bind socket:0
+YARN_NICENESS=1 /usr/bin/ionice -c2 -n0
 HADOOP_CONF_DIR=$localworkdir/conf
 YARN_LOG_DIR=$localworkdir/log
 YARN_PID_DIR=$localworkdir/pid

--- a/hod/config/autogen/hadoop.py
+++ b/hod/config/autogen/hadoop.py
@@ -132,6 +132,7 @@ def yarn_site_xml_defaults(workdir, node_info):
         'yarn.nodemanager.resource.memory-mb': max_alloc,
         'yarn.nodemanager.vmem-check-enabled':'false',
         'yarn.nodemanager.vmem-pmem-ratio': 2.1,
+        'yarn.nodemanager.hostname': '$dataname',
         'yarn.resourcemanager.hostname': '$masterdataname',
         'yarn.resourcemanager.scheduler.class':'org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler',
         'yarn.scheduler.capacity.allocation.file': 'capacity-scheduler.xml',

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -173,7 +173,9 @@ class PreServiceConfigOpts(object):
         for autocfg in self.autogen:
             fn = autogen_fn(autocfg)
             new_configs = fn(self.workdir, node_info)
-            new_configs.update(self.service_configs)
+            for cfgname in new_configs.keys():
+                if cfgname in self.service_configs:
+                    new_configs[cfgname].update(self.service_configs[cfgname])
             self.service_configs = new_configs
 
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def find_files(*dirs):
 
 PACKAGE = {
     'name': 'hanythingondemand',
-    'version': '2.2.2',
+    'version': '2.2.3',
     'author': ['stijn.deweirdt@ugent.be', 'jens.timmerman@ugent.be', 'ewan.higgs@ugent.be'],
     'maintainer': ['stijn.deweirdt@ugent.be', 'jens.timmerman@ugent.be', 'ewan.higgs@ugent.be'],
     'license': "GPL v2",

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -70,7 +70,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
                 cores=24, totalcores=24, usablecores=range(24), topology=[0],
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 9)
+        self.assertEqual(len(d), 10)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], hcc.round_mb(hcc.parse_memory('56G')))
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], hcc.round_mb(hcc.parse_memory('2G')))
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], hcc.round_mb(hcc.parse_memory('56G')))

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -66,7 +66,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
                 cores=4, totalcores=24, usablecores=[0, 1, 2, 3], topology=[0],
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 10)
+        self.assertEqual(len(d), 11)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], 9216)
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], 1024)
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], 9216)


### PR DESCRIPTION
The `hwloc-bind` issue was a howler that prevented a service from using the whole machine. It was a mismerge from the previous incarnation of hanythingondemand.

We also now set `yarn.nodemanager.hostname` to get jobs to talk over IB where possible. Logs suggest the nodemanager and resourcemanager are indeed talking over the IB interfaces but I haven't tested whether the communication is really happening here since I'm only using a single node for testing atm.