### PR TITLE
Module fixes.

### DIFF
--- a/etc/hod/Hadoop-2.3.0-cdh5.0.0/screen.conf
+++ b/etc/hod/Hadoop-2.3.0-cdh5.0.0/screen.conf
@@ -6,9 +6,8 @@ Name=screen
 RunsOn=master
 
 [Service]
-module=Hadoop/2.3.0-cdh5.0.0
 # We run 'exec bash' at the end so screen doesn't exit upon command completion.
-ExecStart=screen -dmS HODclient bash -c "module load %(module)s; HADOOP_CONF_DIR=$localworkdir/conf; exec bash"
+ExecStart=screen -dmS HODclient bash -c 'module load -f $$(module list -t 2>&1 | sed 1,2d ); exec bash'
 ExecStop=
 
 [Environment]

--- a/etc/hod/Hadoop-2.3.0-cdh5.0.0/screen.conf
+++ b/etc/hod/Hadoop-2.3.0-cdh5.0.0/screen.conf
@@ -6,6 +6,8 @@ Name=screen
 RunsOn=master
 
 [Service]
+# We reload the modules because Linux strips LD_ settings when using screen. 
+# - Example description: http://superuser.com/a/235773/141303
 # We run 'exec bash' at the end so screen doesn't exit upon command completion.
 ExecStart=screen -dmS HODclient bash -c 'module load -f $$(module list -t 2>&1 | sed 1,2d ); exec bash'
 ExecStop=

--- a/etc/hod/Hadoop-2.5.0-cdh5.3.1-gpfs/screen.conf
+++ b/etc/hod/Hadoop-2.5.0-cdh5.3.1-gpfs/screen.conf
@@ -6,9 +6,8 @@ Name=screen
 RunsOn=master
 
 [Service]
-module=Hadoop/2.5.0-cdh5.3.1
 # We run 'exec bash' at the end so screen doesn't exit upon command completion.
-ExecStart=screen -dmS HODclient bash -c "module load %(module)s; HADOOP_CONF_DIR=$localworkdir/conf; exec bash"
+ExecStart=screen -dmS HODclient bash -c 'module load -f $$(module list -t 2>&1 | sed 1,2d ); exec bash'
 ExecStop=
 
 [Environment]

--- a/etc/hod/Hadoop-2.5.0-cdh5.3.1-gpfs/screen.conf
+++ b/etc/hod/Hadoop-2.5.0-cdh5.3.1-gpfs/screen.conf
@@ -6,6 +6,8 @@ Name=screen
 RunsOn=master
 
 [Service]
+# We reload the modules because Linux strips LD_ settings when using screen. 
+# - Example description: http://superuser.com/a/235773/141303
 # We run 'exec bash' at the end so screen doesn't exit upon command completion.
 ExecStart=screen -dmS HODclient bash -c 'module load -f $$(module list -t 2>&1 | sed 1,2d ); exec bash'
 ExecStop=

--- a/etc/hod/Hadoop-on-lustre2/hod.conf
+++ b/etc/hod/Hadoop-on-lustre2/hod.conf
@@ -4,7 +4,7 @@
 version=1
 
 [Config]
-modules=Hadoop/2.4.0-seagate
+modules=Hadoop/2.4.0-seagate-722af1-native
 master_env=HADOOP_HOME,EBROOTHADOOP,JAVA_HOME
 services=resourcemanager.conf,nodemanager.conf,screen.conf
 config_writer=hod.config.writer.hadoop_xml

--- a/etc/hod/Hadoop-on-lustre2/screen.conf
+++ b/etc/hod/Hadoop-on-lustre2/screen.conf
@@ -6,9 +6,8 @@ Name=screen
 RunsOn=master
 
 [Service]
-module=Hadoop/2.4.0-seagate
 # We run 'exec bash' at the end so screen doesn't exit upon command completion.
-ExecStart=screen -dmS HODclient bash -c "module load %(module)s; HADOOP_CONF_DIR=$localworkdir/conf; exec bash"
+ExecStart=screen -dmS HODclient bash -c 'module load -f $$(module list -t 2>&1 | sed 1,2d ); exec bash'
 ExecStop=
 
 [Environment]

--- a/etc/hod/Hadoop-on-lustre2/screen.conf
+++ b/etc/hod/Hadoop-on-lustre2/screen.conf
@@ -6,6 +6,8 @@ Name=screen
 RunsOn=master
 
 [Service]
+# We reload the modules because Linux strips LD_ settings when using screen. 
+# - Example description: http://superuser.com/a/235773/141303
 # We run 'exec bash' at the end so screen doesn't exit upon command completion.
 ExecStart=screen -dmS HODclient bash -c 'module load -f $$(module list -t 2>&1 | sed 1,2d ); exec bash'
 ExecStop=

--- a/hod/config/autogen/hadoop_on_lustre2.py
+++ b/hod/config/autogen/hadoop_on_lustre2.py
@@ -52,7 +52,9 @@ def mapred_site_xml_defaults(workdir, node_info):
 
 def yarn_site_xml_defaults(workdir, node_info):
     dflts = {
-        'yarn.nodemanager.local-dirs': '$workdir/$hostname',
+        # Hadoop-on-lustre2 wants to find dirs with
+        # $workdir/$(nodemanager-hostname) which in our case is 'dataname'
+        'yarn.nodemanager.local-dirs': '$workdir/$dataname',
     }
     base_hadoop_dflts = hcah.yarn_site_xml_defaults(workdir, node_info)
     base_hadoop_dflts.update(dflts)

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -115,18 +115,6 @@ def parse_comma_delim_list(s):
     '''
     return [x.strip() for x in filter(lambda x: x.strip(), s.split(','))]
 
-def _extend_list(lst, other):
-    '''Extend the list so 
-    _extend_list([1,2,3], 4) -> [1,2,3,4]
-    _extend_list([1,2,3], [4, 5]) -> [1,2,3,4, 5]
-    '''
-    if isinstance(other, list):
-        lst += other
-    else:
-        lst.append(other)
-    return lst
-
-
 class PreServiceConfigOpts(object):
     r"""
     Manifest file for the group of services responsible for defining service
@@ -155,7 +143,7 @@ class PreServiceConfigOpts(object):
             '''
             lst = parse_comma_delim_list(_cfgget(_config, _CONFIG_SECTION, name, ''))
             if kwargs.get(name, None) is not None:
-                _extend_list(lst, parse_comma_delim_list(kwargs[name]))
+                lst.extend(parse_comma_delim_list(kwargs[name]))
             return lst
 
         self.modules = _get_list('modules')

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -98,7 +98,7 @@ def _cfgget(config, section, item, dflt=None, **kwargs):
     Get a value from a ConfigParser object or a default if it's not there.
     Options in kwargs override the config.
     '''
-    if item in kwargs and kwargs[item] is not None:
+    if kwargs.get(item, None) is not None:
         return kwargs[item]
     if dflt is None:
         return config.get(section, item)
@@ -154,7 +154,7 @@ class PreServiceConfigOpts(object):
             Mergely append.
             '''
             lst = parse_comma_delim_list(_cfgget(_config, _CONFIG_SECTION, name, ''))
-            if name in kwargs and kwargs[name] is not None:
+            if kwargs.get(name, None) is not None:
                 _extend_list(lst, parse_comma_delim_list(kwargs[name]))
             return lst
 

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -115,6 +115,18 @@ def parse_comma_delim_list(s):
     '''
     return [x.strip() for x in filter(lambda x: x.strip(), s.split(','))]
 
+def _extend_list(lst, other):
+    '''Extend the list so 
+    _extend_list([1,2,3], 4) -> [1,2,3,4]
+    _extend_list([1,2,3], [4, 5]) -> [1,2,3,4, 5]
+    '''
+    if isinstance(other, list):
+        lst += other
+    else:
+        lst.append(other)
+    return lst
+
+
 class PreServiceConfigOpts(object):
     r"""
     Manifest file for the group of services responsible for defining service
@@ -137,8 +149,14 @@ class PreServiceConfigOpts(object):
             return _abspath(cfg, fileobj_dir)
 
         def _get_list(name):
-            return parse_comma_delim_list(_cfgget(_config, _CONFIG_SECTION,
-                name, '', **kwargs))
+            '''
+            With lists, we don't want to overwrite the value with kwargs.
+            Mergely append.
+            '''
+            lst = parse_comma_delim_list(_cfgget(_config, _CONFIG_SECTION, name, ''))
+            if name in kwargs and kwargs[name] is not None:
+                _extend_list(lst, parse_comma_delim_list(kwargs[name]))
+            return lst
 
         self.modules = _get_list('modules')
         self.master_env = _get_list('master_env')

--- a/hod/config/hodoption.py
+++ b/hod/config/hodoption.py
@@ -69,6 +69,7 @@ class HodOption(GeneralOption):
 a comma separated list of config files with the later files taking
 precendence.""", "string", "store", ''),
                 'workdir': ("""Working directory""", "string", "store", None),
+                'modules': ("""Extra modules to load in each service environment""", "string", "store", None),
                 }
         descr = ["Config", "Configuration files options"]
 

--- a/hod/config/template.py
+++ b/hod/config/template.py
@@ -72,10 +72,19 @@ class TemplateRegistry(object):
         return kwargs
 
 
-def register_templates(template_registry, workdir):
+def register_templates(template_registry, config_opts):
     '''
     Register the common templates.
+    Params
+    ------
+    template_registry : `TemplateRegistry`
+        Registry to update.
+
+    config_opts : `hod.mpiservice.ConfigOptsParams`
+        Configuration structure holding our config options.
     '''
+    workdir = config_opts.workdir
+    modules = config_opts.modules
     local_data_network = node.sorted_network(node.get_networks())[0]
     templates = [
         _config_template_stub('masterhostname', 'Hostname bound to the Fully Qualified Domain Name (FQDN) of the master node.'),
@@ -88,6 +97,7 @@ def register_templates(template_registry, workdir):
         ConfigTemplate('localworkdir', lambda: mklocalworkdir(workdir), 'Subdirectory of workdir with user, host, and pid in the name to make it distinct from other workdirs for use on shared file systems'),
         ConfigTemplate('user', _current_user, 'Current user'),
         ConfigTemplate('pid', os.getpid, 'PID for the current process'),
+        ConfigTemplate('modules', lambda: ' '.join(modules), 'Modules listed in the hod.conf'),
         ]
 
     for ct in templates:

--- a/hod/hodproc.py
+++ b/hod/hodproc.py
@@ -73,14 +73,14 @@ def _setup_config_paths(precfg, resolver):
         dest_path = mkpath(precfg.configdir, dest_file)
         write_service_config(dest_path, cfg, config_writer, resolver)
 
-def _load_manifest_config(filenames, workdir):
+def _load_manifest_config(filenames, workdir, modules):
     '''
     Load the manifest config (hod.conf) files.
     '''
     m_config_filenames = parse_comma_delim_list(filenames)
     _log.info('Loading "%s" manifest config', m_config_filenames)
     m_config = preserviceconfigopts_from_file_list(m_config_filenames,
-            workdir=workdir)
+            workdir=workdir, modules=modules)
     _log.debug('Loaded manifest config: %s', str(m_config))
     return m_config
 
@@ -89,7 +89,7 @@ def _setup_template_resolver(m_config, master_template_args):
     Build a template resovler using the template args from the master node.
     '''
     reg = TemplateRegistry()
-    register_templates(reg, m_config.workdir)
+    register_templates(reg, m_config)
     for ct in master_template_args:
         reg.register(ct)
     return TemplateResolver(**reg.to_kwargs())
@@ -106,7 +106,8 @@ class ConfiguredMaster(MpiService):
         """Master makes the distribution"""
         self.tasks = []
         m_config = _load_manifest_config(self.options.options.config_config,
-                self.options.options.config_workdir)
+                self.options.options.config_workdir, 
+                self.options.options.config_modules)
         m_config.autogen_configs()
 
         resolver = _setup_template_resolver(m_config, master_template_args)
@@ -123,7 +124,7 @@ class ConfiguredMaster(MpiService):
             ranks_to_run = config.runs_on(MASTERRANK, range(self.size))
             self.log.debug('Adding ConfiguredService Task to work with config: %s',
                     str(config))
-            cfg_opts = ConfigOptsParams(config_filename, m_config.workdir, master_template_args)
+            cfg_opts = ConfigOptsParams(config_filename, m_config.workdir, m_config.modules, master_template_args)
             self.tasks.append(Task(ConfiguredService, config.name, ranks_to_run, cfg_opts, master_env))
 
 class ConfiguredSlave(MpiService):
@@ -141,7 +142,8 @@ class ConfiguredSlave(MpiService):
         This only needs to run if there are more than 1 node (self.size>1)
         """
         m_config = _load_manifest_config(self.options.options.config_config,
-                self.options.options.config_workdir)
+                self.options.options.config_workdir,
+                self.options.options.config_modules)
         m_config.autogen_configs()
         resolver = _setup_template_resolver(m_config, master_template_args)
         _setup_config_paths(m_config, resolver)

--- a/hod/mpiservice.py
+++ b/hod/mpiservice.py
@@ -48,7 +48,8 @@ MASTERRANK = 0
 
 # Parameters to send over the network to allow slaves to construct hod.config.ConfigOpts
 # objects
-ConfigOptsParams = namedtuple('ConfigOptsParams', ['filename', 'workdir', 'master_template_kwargs'])
+
+ConfigOptsParams = namedtuple('ConfigOptsParams', ['filename', 'workdir', 'modules', 'master_template_kwargs'])
 Task = namedtuple('Task', ['type', 'name', 'ranks', 'config_opts', 'master_env'])
 
 def _who_is_out_there(comm, rank):
@@ -148,7 +149,7 @@ def setup_tasks(svc):
 
 def _mkconfigopts(cfg_opts):
     reg = TemplateRegistry()
-    register_templates(reg, cfg_opts.workdir)
+    register_templates(reg, cfg_opts)
     for ct  in cfg_opts.master_template_kwargs:
         reg.register(ct)
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def find_files(*dirs):
 
 PACKAGE = {
     'name': 'hanythingondemand',
-    'version': '2.2.3',
+    'version': '2.2.4',
     'author': ['stijn.deweirdt@ugent.be', 'jens.timmerman@ugent.be', 'ewan.higgs@ugent.be'],
     'maintainer': ['stijn.deweirdt@ugent.be', 'jens.timmerman@ugent.be', 'ewan.higgs@ugent.be'],
     'license': "GPL v2",

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -72,6 +72,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
         d = hca.yarn_site_xml_defaults('/', node)
         self.assertEqual(len(d), 10)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], hcc.round_mb(hcc.parse_memory('56G')))
+        self.assertEqual(d['yarn.nodemanager.hostname'], '$dataname')
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], hcc.round_mb(hcc.parse_memory('2G')))
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], hcc.round_mb(hcc.parse_memory('56G')))
 

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -29,6 +29,7 @@ Nothing here for now.
 """
 
 import unittest
+from os.path import basename
 from mock import patch, MagicMock
 
 import hod.config.autogen.common as hcc
@@ -71,6 +72,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], 1024)
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], 9216)
         self.assertEqual(d['yarn.nodemanager.local-dirs'], '$workdir/$dataname')
+        self.assertEqual(basename(d['yarn.nodemanager.local-dirs']), d['yarn.nodemanager.hostname'])
 
     def test_autogen_config(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -70,7 +70,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], 9216)
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], 1024)
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], 9216)
-        self.assertEqual(d['yarn.nodemanager.local-dirs'], '$workdir/$hostname')
+        self.assertEqual(d['yarn.nodemanager.local-dirs'], '$workdir/$dataname')
 
     def test_autogen_config(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -62,6 +62,33 @@ wibble.class=super
         self.assertEqual(precfg.directories, ['/dfs/name', '/dfs/data'])
         self.assertEqual(hcc.invalid_fields(precfg), [])
 
+    def test_PreServiceConfigOpts_kwargs(self):
+        config = StringIO("""
+[Meta]
+version=1
+
+[Config]
+master_env=TMPDIR
+modules=powerlevel/9001,scouter/1.0
+services=scouter.conf
+config_writer=hod.config.writer.scouter_yaml
+directories=/dfs/name,/dfs/data
+
+[scouter.yaml]
+wibble=abc
+wibble.class=super
+        """)
+        precfg = hcc.PreServiceConfigOpts(config, workdir='dbz-quotes',
+                modules='dbz/episode-28')
+        self.assertEqual(precfg.modules, ['powerlevel/9001', 'scouter/1.0',
+            'dbz/episode-28'])
+        for x in precfg.service_files:
+            self.assertTrue(basename(x) in ['scouter.conf'])
+        self.assertTrue('scouter.yaml' in precfg.service_configs.keys())
+        self.assertEqual(precfg.directories, ['/dfs/name', '/dfs/data'])
+        self.assertEqual(hcc.invalid_fields(precfg), [])
+        self.assertEqual(precfg.workdir, 'dbz-quotes')
+
     def test_PreServiceConfigOpts_invalid(self):
         config = StringIO("""
 [Meta]

--- a/test/unit/config/test_template.py
+++ b/test/unit/config/test_template.py
@@ -26,7 +26,7 @@
 '''
 
 import unittest
-from mock import patch 
+from mock import patch, Mock
 from os.path import basename
 from cStringIO import StringIO
 from cPickle import dumps, loads
@@ -36,9 +36,28 @@ import hod.config.template as hct
 class TestConfigTemplate(unittest.TestCase):
     def test_register_templates(self):
         reg = hct.TemplateRegistry()
-        hct.register_templates(reg, 'workdir')
+        cfg = Mock(workdir='workdir', modules=['MyModule'])
+        hct.register_templates(reg, cfg)
         self.assertEqual(reg.fields['masterhostname'].name, 'masterhostname')
         self.assertTrue(len(reg.fields['masterhostname'].doc) != 0)
+        self.assertEqual(reg.fields['modules'].name, 'modules')
+        self.assertEqual(reg.fields['modules'].fn(), 'MyModule')
+
+    def test_register_templates_no_modules(self):
+        reg = hct.TemplateRegistry()
+        cfg = Mock(workdir='workdir', modules=[])
+        hct.register_templates(reg, cfg)
+        self.assertEqual(reg.fields['masterhostname'].name, 'masterhostname')
+        self.assertTrue(len(reg.fields['masterhostname'].doc) != 0)
+        self.assertEqual(reg.fields['modules'].fn(), '')
+
+    def test_register_templates_multi_modules(self):
+        reg = hct.TemplateRegistry()
+        cfg = Mock(workdir='workdir', modules=['MyModule', 'MyOtherModule'])
+        hct.register_templates(reg, cfg)
+        self.assertEqual(reg.fields['masterhostname'].name, 'masterhostname')
+        self.assertTrue(len(reg.fields['masterhostname'].doc) != 0)
+        self.assertEqual(reg.fields['modules'].fn(), 'MyModule MyOtherModule')
 
     def test_TemplateRegistry(self):
         reg = hct.TemplateRegistry()

--- a/test/unit/test_hodproc.py
+++ b/test/unit/test_hodproc.py
@@ -67,7 +67,8 @@ class TestHodProcConfiguredMaster(unittest.TestCase):
         self.assertEqual(cm.options, opts)
 
     def test_configured_master_distribution(self):
-        opts = HodOption(go_args=['progname', '--config-config', 'hod.conf'])
+        opts = HodOption(go_args=['progname', '--config-config', 'hod.conf',
+        '--config-modules', 'Python-2.7.9-intel-2015a,Spark/1.3.0'])
         autogen_config = Mock()
         cm = hh.ConfiguredMaster(opts)
         with patch('hod.hodproc._setup_config_paths', side_effect=lambda *args: None):
@@ -78,8 +79,12 @@ class TestHodProcConfiguredMaster(unittest.TestCase):
         self.assertEqual(len(cm.tasks), 1)
         self.assertTrue(autogen_config.called)
         self.assertEqual(autogen_config.call_count, 1)
+        self.assertTrue('Python-2.7.9-intel-2015a' in cm.tasks[0].config_opts.modules)
+        self.assertTrue('Spark/1.3.0' in cm.tasks[0].config_opts.modules)
+
     def test_configured_slave_distribution(self):
-        opts = HodOption(go_args=['progname', '--config-config', 'hod.conf'])
+        opts = HodOption(go_args=['progname', '--config-config', 'hod.conf',
+        '--config-modules', 'Python-2.7.9-intel-2015a,Spark/1.3.0'])
         autogen_config = Mock()
         cm = hh.ConfiguredSlave(opts)
         with patch('hod.hodproc._setup_config_paths', side_effect=lambda *args: None):


### PR DESCRIPTION
1. Add ability to load modules from the command line using
`--config-modules=comma,separated,list`
This allows us to use something like Hadoop-2.3.0 configs but then also load up Spark and Python by just passing `--config-modules=Python/2.7.9-intel-2015a,Spark/1.3.0` on the `hod_pbs.py` command line. This is required if we want the `nodemanager` to be able to find an appropriate Python to run when using `pyspark` without having to hack configs.

2. Add `$modules` as a template param for services to use.

3. Fix screen session so it reloads the loaded modules to fix the fact that
screen strips the `LD_` environment variables. This allows us to load things like Python in the screen session and it should actually work(!)

4. Bump version to 2.2.4