### PR TITLE
Change default scheduler calculator to DominantResourceCalculator

### DIFF
--- a/hod/config/autogen/hadoop.py
+++ b/hod/config/autogen/hadoop.py
@@ -134,7 +134,9 @@ def yarn_site_xml_defaults(workdir, node_info):
         'yarn.nodemanager.vmem-pmem-ratio': 2.1,
         'yarn.nodemanager.hostname': '$dataname',
         'yarn.resourcemanager.hostname': '$masterdataname',
-        'yarn.resourcemanager.scheduler.class':'org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler',
+        'yarn.resourcemanager.webapp.address': '$masterhostname:8088',
+        'yarn.resourcemanager.webapp.https.address': '$masterhostname:8090',
+        'yarn.resourcemanager.scheduler.class': 'org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler',
         'yarn.scheduler.capacity.allocation.file': 'capacity-scheduler.xml',
     }
     return dflts
@@ -144,6 +146,7 @@ def capacity_scheduler_xml_defaults(workdir, node_info):
         'yarn.scheduler.capacity.root.queues': 'default',
         'yarn.scheduler.capacity.root.default.capacity': 100,
         'yarn.scheduler.capacity.root.default.minimum-user-limit-percent': 100,
+        'yarn.scheduler.capacity.resource-calculator': 'org.apache.hadoop.yarn.util.resource.DominantResourceCalculator'
     }
     return dflts
 

--- a/hod/config/autogen/hadoop.py
+++ b/hod/config/autogen/hadoop.py
@@ -133,6 +133,7 @@ def yarn_site_xml_defaults(workdir, node_info):
         'yarn.nodemanager.vmem-check-enabled':'false',
         'yarn.nodemanager.vmem-pmem-ratio': 2.1,
         'yarn.nodemanager.hostname': '$dataname',
+        'yarn.nodemanager.webapp.address': '$hostname:8042',
         'yarn.resourcemanager.hostname': '$masterdataname',
         'yarn.resourcemanager.webapp.address': '$masterhostname:8088',
         'yarn.resourcemanager.webapp.https.address': '$masterhostname:8090',

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -70,8 +70,10 @@ class TestConfigAutogenHadoop(unittest.TestCase):
                 cores=24, totalcores=24, usablecores=range(24), topology=[0],
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 10)
+        self.assertEqual(len(d), 12)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], hcc.round_mb(hcc.parse_memory('56G')))
+        self.assertEqual(d['yarn.resourcemanager.webapp.address'], '$masterhostname:8088')
+        self.assertEqual(d['yarn.resourcemanager.webapp.https.address'], '$masterhostname:8090')
         self.assertEqual(d['yarn.nodemanager.hostname'], '$dataname')
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], hcc.round_mb(hcc.parse_memory('2G')))
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], hcc.round_mb(hcc.parse_memory('56G')))
@@ -81,11 +83,12 @@ class TestConfigAutogenHadoop(unittest.TestCase):
                 cores=24, totalcores=24, usablecores=range(24), topology=[0],
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.capacity_scheduler_xml_defaults('/', node)
-        self.assertEqual(len(d), 3)
+        self.assertEqual(len(d), 4)
         self.assertEqual(d['yarn.scheduler.capacity.root.queues'], 'default')
         self.assertEqual(d['yarn.scheduler.capacity.root.default.capacity'], 100)
         self.assertEqual(d['yarn.scheduler.capacity.root.default.minimum-user-limit-percent'], 100)
-
+        self.assertEqual(d['yarn.scheduler.capacity.resource-calculator'], 
+                'org.apache.hadoop.yarn.util.resource.DominantResourceCalculator')
     def test_autogen_config(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
                 cores=24, totalcores=24, usablecores=range(24), topology=[0],

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -70,11 +70,12 @@ class TestConfigAutogenHadoop(unittest.TestCase):
                 cores=24, totalcores=24, usablecores=range(24), topology=[0],
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 12)
+        self.assertEqual(len(d), 13)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], hcc.round_mb(hcc.parse_memory('56G')))
         self.assertEqual(d['yarn.resourcemanager.webapp.address'], '$masterhostname:8088')
         self.assertEqual(d['yarn.resourcemanager.webapp.https.address'], '$masterhostname:8090')
         self.assertEqual(d['yarn.nodemanager.hostname'], '$dataname')
+        self.assertEqual(d['yarn.nodemanager.webapp.address'], '$hostname:8042')
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], hcc.round_mb(hcc.parse_memory('2G')))
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], hcc.round_mb(hcc.parse_memory('56G')))
 

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -67,7 +67,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
                 cores=4, totalcores=24, usablecores=[0, 1, 2, 3], topology=[0],
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 13)
+        self.assertEqual(len(d), 14)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], 9216)
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], 1024)
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], 9216)

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -67,7 +67,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
                 cores=4, totalcores=24, usablecores=[0, 1, 2, 3], topology=[0],
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 11)
+        self.assertEqual(len(d), 13)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], 9216)
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], 1024)
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], 9216)


### PR DESCRIPTION
Change default scheduler calculator to DominantResourceCalculator on Dries Decap's
suggestion since DRC uses cpu as well as memory for scheduling decisions.
CapacityScheduler only uses memory so it can allegedly run into issues on high
memory machines where it tries to schedule too many tasks.

Make the web service use the default hostname interface (i.e. ethernet) for the
web services.