### PR TITLE
Use the hostaddress for the web app information. 

### DIFF
--- a/hod/config/autogen/hadoop.py
+++ b/hod/config/autogen/hadoop.py
@@ -133,10 +133,10 @@ def yarn_site_xml_defaults(workdir, node_info):
         'yarn.nodemanager.vmem-check-enabled':'false',
         'yarn.nodemanager.vmem-pmem-ratio': 2.1,
         'yarn.nodemanager.hostname': '$dataname',
-        'yarn.nodemanager.webapp.address': '$hostname:8042',
+        'yarn.nodemanager.webapp.address': '$hostaddress:8042',
         'yarn.resourcemanager.hostname': '$masterdataname',
-        'yarn.resourcemanager.webapp.address': '$masterhostname:8088',
-        'yarn.resourcemanager.webapp.https.address': '$masterhostname:8090',
+        'yarn.resourcemanager.webapp.address': '$masterhostaddress:8088',
+        'yarn.resourcemanager.webapp.https.address': '$masterhostaddress:8090',
         'yarn.resourcemanager.scheduler.class': 'org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler',
         'yarn.scheduler.capacity.allocation.file': 'capacity-scheduler.xml',
     }

--- a/hod/config/template.py
+++ b/hod/config/template.py
@@ -88,7 +88,9 @@ def register_templates(template_registry, config_opts):
     local_data_network = node.sorted_network(node.get_networks())[0]
     templates = [
         _config_template_stub('masterhostname', 'Hostname bound to the Fully Qualified Domain Name (FQDN) of the master node.'),
-        _config_template_stub('masterdataname', 'Hostname bound to the Infiniband adaptor on the master node if available'),
+        _config_template_stub('masterhostaddress', 'Address bound to the default interface.'),
+        _config_template_stub('masterdataname', 'Hostname bound to the Infiniband adapter on the master node if available.'),
+        _config_template_stub('masterdataaddress', 'Address bound to the Infiniband adapter on the master node if available.'),
         ConfigTemplate('hostname', socket.getfqdn, 'Fully Qualified Domain Name (FQDN)'),
         ConfigTemplate('hostaddress', lambda: socket.gethostbyname(socket.getfqdn()), 'IP address registered as the FQDN'),
         ConfigTemplate('dataname', local_data_network.hostname, 'Infiniband hostname if available'),

--- a/hod/mpiservice.py
+++ b/hod/mpiservice.py
@@ -133,8 +133,8 @@ def setup_tasks(svc):
         master_dataaddress = data_interface.addr
         fqdn = socket.getfqdn()
         master_template_kwargs = [
-                ConfigTemplate('masterhostname',fqdn,''),
-                ConfigTemplate('masterhostaddress',socket.gethostbyname(fqdn),''),
+                ConfigTemplate('masterhostname', fqdn,''),
+                ConfigTemplate('masterhostaddress', socket.gethostbyname(fqdn),''),
                 ConfigTemplate('masterdataname', master_dataname, ''),
                 ConfigTemplate('masterdataaddress', master_dataaddress, '')
                 ]

--- a/hod/mpiservice.py
+++ b/hod/mpiservice.py
@@ -128,10 +128,15 @@ def setup_tasks(svc):
 
     # Configure
     if svc.rank == MASTERRANK:
-        master_dataname = node.sorted_network(node.get_networks())[0].hostname
+        data_interface = node.sorted_network(node.get_networks())[0]
+        master_dataname = data_interface.hostname
+        master_dataaddress = data_interface.addr
+        fqdn = socket.getfqdn()
         master_template_kwargs = [
-                ConfigTemplate('masterhostname',socket.getfqdn(),''),
-                ConfigTemplate('masterdataname', master_dataname, '')
+                ConfigTemplate('masterhostname',fqdn,''),
+                ConfigTemplate('masterhostaddress',socket.gethostbyname(fqdn),''),
+                ConfigTemplate('masterdataname', master_dataname, ''),
+                ConfigTemplate('masterdataaddress', master_dataaddress, '')
                 ]
         _master_spread(svc.comm, master_template_kwargs)
     else:

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -72,10 +72,10 @@ class TestConfigAutogenHadoop(unittest.TestCase):
         d = hca.yarn_site_xml_defaults('/', node)
         self.assertEqual(len(d), 13)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], hcc.round_mb(hcc.parse_memory('56G')))
-        self.assertEqual(d['yarn.resourcemanager.webapp.address'], '$masterhostname:8088')
-        self.assertEqual(d['yarn.resourcemanager.webapp.https.address'], '$masterhostname:8090')
+        self.assertEqual(d['yarn.resourcemanager.webapp.address'], '$masterhostaddress:8088')
+        self.assertEqual(d['yarn.resourcemanager.webapp.https.address'], '$masterhostaddress:8090')
         self.assertEqual(d['yarn.nodemanager.hostname'], '$dataname')
-        self.assertEqual(d['yarn.nodemanager.webapp.address'], '$hostname:8042')
+        self.assertEqual(d['yarn.nodemanager.webapp.address'], '$hostaddress:8042')
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], hcc.round_mb(hcc.parse_memory('2G')))
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], hcc.round_mb(hcc.parse_memory('56G')))
 


### PR DESCRIPTION
The Hadoop web app uses the fqdn of the nodemanager or resource manager in the web app to make urls. This means that clicking around the web app you get links that will point to `node1234.mycluster` which probably only exists in your DNS for your cluster and not for the outside world (or even VPN). The result is that the links become effectively dead.

This patch tells hadoop about the IP address instead.Sadly Hadoop has ignores the fact that you provided an IP and inserts a FQDN instead. I'm talking on the user list to see if I should escalate this to a bug.