### PR TITLE
Add hod-help-template command that will print diagnostic details.

### DIFF
--- a/bin/hod-help-template
+++ b/bin/hod-help-template
@@ -35,24 +35,32 @@ import sys
 from hod.mpiservice import ConfigOptsParams, master_template_opts
 import hod.node.node as node
 
-def main(args):
-
+def mk_registry():
+    """Make a TemplateRegistry and register basic items"""
     config_opts = ConfigOptsParams(filename='hod.conf', workdir='WORKDIR',
-            modules=['MODULES'], master_template_kwargs=[])
-
+        modules=['MODULES'], master_template_kwargs=[])
     reg = hct.TemplateRegistry()
     hct.register_templates(reg, config_opts)
     master_template_kwargs = master_template_opts(reg.fields.values())
     for ct in master_template_kwargs:
         reg.register(ct)
-    resolver = hct.TemplateResolver(**reg.to_kwargs())
-    print 'Hanythingondemand template parameters'
-    longest_name = max(reg.fields.values(), key=lambda x: len(x.name)).name
+    return reg
+
+def mk_fmt_str(fields, resolver):
+    """Calculate the format string for printing the template parameters."""
+    longest_name = max(fields.values(), key=lambda x: len(x.name)).name
     max_name_len = len(longest_name)
-    value_names = map(resolver, ['$%s'% v.name for v in reg.fields.values()])
+    value_names = map(resolver, ['$%s'% v.name for v in fields.values()])
     longest_value = max(value_names, key=len)
     max_val_len = len(longest_value)
-    fmt_str = '%%-%ds:\t%%-%ds\t%%s' % (max_name_len, max_val_len)
+    return '%%-%ds:\t%%-%ds\t%%s' % (max_name_len, max_val_len)
+
+
+def main(args):
+    reg = mk_registry()
+    resolver = hct.TemplateResolver(**reg.to_kwargs())
+    print 'Hanythingondemand template parameters'
+    fmt_str = mk_fmt_str(reg.fields, resolver)
     print fmt_str % ('Parameter name', 'Value', 'Documentation')
     for v in sorted(reg.fields.values(), key=lambda x: x.name):
         print fmt_str % (v.name, resolver('$%s' % v.name), v.doc)

--- a/bin/hod-help-template
+++ b/bin/hod-help-template
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# ##
+# Copyright 2009-2015 Ghent University
+#
+# This file is part of hanythingondemand
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/hanythingondemand
+#
+# hanythingondemand is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# hanythingondemand is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hanythingondemand. If not, see <http://www.gnu.org/licenses/>.
+"""
+Print out template parameters used by hod.
+
+@author: Ewan Higgs (Ghent University)
+"""
+
+import hod.config.template as hct
+import socket
+import sys
+
+from hod.mpiservice import ConfigOptsParams, master_template_opts
+import hod.node.node as node
+
+def main(args):
+
+    config_opts = ConfigOptsParams(filename='hod.conf', workdir='WORKDIR',
+            modules=['MODULES'], master_template_kwargs=[])
+
+    reg = hct.TemplateRegistry()
+    hct.register_templates(reg, config_opts)
+    master_template_kwargs = master_template_opts(reg.fields.values())
+    for ct in master_template_kwargs:
+        reg.register(ct)
+    resolver = hct.TemplateResolver(**reg.to_kwargs())
+    print 'Hanythingondemand template parameters'
+    longest_name = max(reg.fields.values(), key=lambda x: len(x.name)).name
+    max_name_len = len(longest_name)
+    value_names = map(resolver, ['$%s'% v.name for v in reg.fields.values()])
+    longest_value = max(value_names, key=len)
+    max_val_len = len(longest_value)
+    fmt_str = '%%-%ds:\t%%-%ds\t%%s' % (max_name_len, max_val_len)
+    print fmt_str % ('Parameter name', 'Value', 'Documentation')
+    for v in sorted(reg.fields.values(), key=lambda x: x.name):
+        print fmt_str % (v.name, resolver('$%s' % v.name), v.doc)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/hod/config/template.py
+++ b/hod/config/template.py
@@ -88,7 +88,9 @@ def register_templates(template_registry, config_opts):
     local_data_network = node.sorted_network(node.get_networks())[0]
     templates = [
         _config_template_stub('masterhostname', 'Hostname bound to the Fully Qualified Domain Name (FQDN) of the master node.'),
+        _config_template_stub('masterhostaddress', 'Address bound to the Fully Qualified Domain Name (FQDN) of the master node.'),
         _config_template_stub('masterdataname', 'Hostname bound to the Infiniband adaptor on the master node if available'),
+        _config_template_stub('masterdataaddress', 'Address bound to the Infiniband adaptor on the master node if available'),
         ConfigTemplate('hostname', socket.getfqdn, 'Fully Qualified Domain Name (FQDN)'),
         ConfigTemplate('hostaddress', lambda: socket.gethostbyname(socket.getfqdn()), 'IP address registered as the FQDN'),
         ConfigTemplate('dataname', local_data_network.hostname, 'Infiniband hostname if available'),

--- a/hod/mpiservice.py
+++ b/hod/mpiservice.py
@@ -137,11 +137,11 @@ def master_template_opts(stub_config_opts=None):
     if stub_config_opts is not None:
         docs = dict([(opt.name, opt.doc) for opt in stub_config_opts])
     return [
-            ConfigTemplate('masterhostname', fqdn, docs.get('masterhostname', '')),
-            ConfigTemplate('masterhostaddress', socket.gethostbyname(fqdn), docs.get('masterhostaddress', '')),
-            ConfigTemplate('masterdataname', master_dataname, docs.get('masterdataname', '')),
-            ConfigTemplate('masterdataaddress', master_dataaddress, docs.get('masterdataaddress', '')),
-            ]
+        ConfigTemplate('masterhostname', fqdn, docs.get('masterhostname', '')),
+        ConfigTemplate('masterhostaddress', socket.gethostbyname(fqdn), docs.get('masterhostaddress', '')),
+        ConfigTemplate('masterdataname', master_dataname, docs.get('masterdataname', '')),
+        ConfigTemplate('masterdataaddress', master_dataaddress, docs.get('masterdataaddress', '')),
+        ]
  
 def setup_tasks(svc):
     """Setup the per node services and spread the tasks out."""

--- a/hod/mpiservice.py
+++ b/hod/mpiservice.py
@@ -122,17 +122,34 @@ def _slave_spread(comm):
     _log.debug("Received '%s' from masterrank %s", tasks, MASTERRANK)
     return tasks
 
+def master_template_opts(stub_config_opts=None):
+    '''
+    Generate template options for the master node.
+
+    If stub_config_opts is given, this function pulls the doctrings from the existing
+    configuration
+    '''
+    data_interface = node.sorted_network(node.get_networks())[0]
+    master_dataname = data_interface.hostname
+    master_dataaddress = data_interface.addr
+    fqdn = socket.getfqdn()
+    docs = dict()
+    if stub_config_opts is not None:
+        docs = dict([(opt.name, opt.doc) for opt in stub_config_opts])
+    return [
+            ConfigTemplate('masterhostname', fqdn, docs.get('masterhostname', '')),
+            ConfigTemplate('masterhostaddress', socket.gethostbyname(fqdn), docs.get('masterhostaddress', '')),
+            ConfigTemplate('masterdataname', master_dataname, docs.get('masterdataname', '')),
+            ConfigTemplate('masterdataaddress', master_dataaddress, docs.get('masterdataaddress', '')),
+            ]
+ 
 def setup_tasks(svc):
     """Setup the per node services and spread the tasks out."""
     _log.debug("No tasks found. Running distribution and spread.")
 
     # Configure
     if svc.rank == MASTERRANK:
-        master_dataname = node.sorted_network(node.get_networks())[0].hostname
-        master_template_kwargs = [
-                ConfigTemplate('masterhostname',socket.getfqdn(),''),
-                ConfigTemplate('masterdataname', master_dataname, '')
-                ]
+        master_template_kwargs = master_template_opts()
         _master_spread(svc.comm, master_template_kwargs)
     else:
         master_template_kwargs = _slave_spread(svc.comm)

--- a/test/unit/test_mpiservice.py
+++ b/test/unit/test_mpiservice.py
@@ -80,7 +80,7 @@ class MPIServiceTestCase(unittest.TestCase):
         ms = hm.MpiService()
         ms.distribution() # TODO:  Does nothing. If it's an interface, make abstract.
 
-    def test_master_template_opts(self):
+    def test_master_template_opts_default(self):
         opts = hm.master_template_opts()
         self.assertTrue(len(opts) == 4)
         self.assertEqual(opts[0].name, 'masterhostname')
@@ -92,7 +92,7 @@ class MPIServiceTestCase(unittest.TestCase):
         self.assertEqual(opts[3].name, 'masterdataaddress')
         self.assertEqual(opts[3].doc, '')
 
-    def test_master_template_opts(self):
+    def test_master_template_opts_enriched(self):
         docs = sentinel 
         stub_docs = [
             ConfigTemplate('masterhostname', None, docs.masterhostname),

--- a/test/unit/test_mpiservice.py
+++ b/test/unit/test_mpiservice.py
@@ -28,6 +28,9 @@
 import unittest
 import hod.mpiservice as hm
 
+from mock import sentinel
+from hod.config.template import ConfigTemplate
+
 class MPIServiceTestCase(unittest.TestCase):
     '''Test MpiService functions'''
 
@@ -76,6 +79,38 @@ class MPIServiceTestCase(unittest.TestCase):
         '''test mpiservice distribution'''
         ms = hm.MpiService()
         ms.distribution() # TODO:  Does nothing. If it's an interface, make abstract.
+
+    def test_master_template_opts(self):
+        opts = hm.master_template_opts()
+        self.assertTrue(len(opts) == 4)
+        self.assertEqual(opts[0].name, 'masterhostname')
+        self.assertEqual(opts[0].doc, '')
+        self.assertEqual(opts[1].name, 'masterhostaddress')
+        self.assertEqual(opts[1].doc, '')
+        self.assertEqual(opts[2].name, 'masterdataname')
+        self.assertEqual(opts[2].doc, '')
+        self.assertEqual(opts[3].name, 'masterdataaddress')
+        self.assertEqual(opts[3].doc, '')
+
+    def test_master_template_opts(self):
+        docs = sentinel 
+        stub_docs = [
+            ConfigTemplate('masterhostname', None, docs.masterhostname),
+            ConfigTemplate('masterhostaddress', None, docs.masterhostaddress),
+            ConfigTemplate('masterdataname', None, docs.masterdataname),
+            ConfigTemplate('masterdataaddress', None, docs.masterdataaddress)
+            ]
+        opts = hm.master_template_opts(stub_docs)
+        self.assertTrue(len(opts) == 4)
+        self.assertEqual(opts[0].name, 'masterhostname')
+        self.assertEqual(opts[0].doc, docs.masterhostname)
+        self.assertEqual(opts[1].name, 'masterhostaddress')
+        self.assertEqual(opts[1].doc, docs.masterhostaddress)
+        self.assertEqual(opts[2].name, 'masterdataname')
+        self.assertEqual(opts[2].doc, docs.masterdataname)
+        self.assertEqual(opts[3].name, 'masterdataaddress')
+        self.assertEqual(opts[3].doc, docs.masterdataaddress)
+
 
     def test_master_spread(self):
         '''test master spread'''


### PR DESCRIPTION
This tool prints out the resolution of the various templates to the command
line.

Run using: `./bin/hod-help-template`
The output looks like this on my machine:

```
$  bin/hod-help-template 
Hanythingondemand template parameters
Parameter name   :	Value                           	Documentation
dataaddress      :	157.193.44.242                  	Infiniband address if available
dataname         :	gast044b.ugent.be               	Infiniband hostname if available
hostaddress      :	157.193.44.242                  	IP address registered as the FQDN
hostname         :	squirtle                        	Fully Qualified Domain Name (FQDN)
localworkdir     :	WORKDIR/hod/ehiggs.squirtle.3538	Subdirectory of workdir with user, host, and pid in the name to make it distinct from other workdirs for use on shared file systems
masterdataaddress:	157.193.44.242                  	Address bound to the Infiniband adaptor on the master node if available
masterdataname   :	gast044b.ugent.be               	Hostname bound to the Infiniband adaptor on the master node if available
masterhostaddress:	157.193.44.242                  	Address bound to the Fully Qualified Domain Name (FQDN) of the master node.
masterhostname   :	squirtle                        	Hostname bound to the Fully Qualified Domain Name (FQDN) of the master node.
modules          :	MODULES                         	Modules listed in the hod.conf
pid              :	3538                            	PID for the current process
user             :	ehiggs                          	Current user
workdir          :	WORKDIR                         	Base directory for configuration and logging, e.g. /tmp, or somewhere on a shared file system.

```