### PR TITLE
Improve import fail error msg

### DIFF
--- a/hod/rmscheduler/rm_pbs.py
+++ b/hod/rmscheduler/rm_pbs.py
@@ -49,7 +49,7 @@ except ImportError as err:
         """Decorator which raises an ImportError because pbs_python is not available."""
         def fail(*args, **kwargs):
             """Raise ImportError since pbs_python is not available."""
-            raise err
+            raise ImportError("%s; pbs_python is not available" % err)
 
         return fail
 


### PR DESCRIPTION
error message like `ImportError: No module named PBSQuery (No module named PBSQuery)` may be too cryptic for users?

Now results in this:

```
ImportError: No module named PBSQuery; pbs_python is not available (No module named PBSQuery; pbs_python is not available)
```