### PR TITLE
Batch subcommand

### DIFF
--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -177,8 +177,20 @@ The label can be used to later connect to the cluster while it is running (see :
 ``hod batch --job-*``
 ++++++++++++++++++++++
 
-The resources being requested for the job that is submitted can be controlled via the available ``--job`` options,
-see :ref:`cmdline_job_options`.
+The resources being requested for the job that is submitted can be controlled via the available ``--job`` options.
+
+See :ref:`cmdline_job_options`.
+
+
+.. _cmdline_batch_options_modules:
+
+``hod batch --modules <module names>``
+++++++++++++++++++++++++++++++++++++++
+
+This acts the same as ``--modules`` for the ``create`` subcommand.
+
+See :ref:`cmdline_create_options_modules`
+
 
 .. _cmdline_list:
 

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -305,33 +305,29 @@ class ConfigOpts(object):
     @staticmethod
     def from_file(fileobj, template_resolver):
         """Load a ConfigOpts from a configuration file."""
-        _config = load_service_config(fileobj)
+        config = load_service_config(fileobj)
 
-        name = _cfgget(_config, _UNIT_SECTION, 'Name')
-        runs_on = _parse_runs_on(_cfgget(_config, _UNIT_SECTION, 'RunsOn'))
-        pre_start_script = _cfgget(_config, _SERVICE_SECTION, 'ExecStartPre', '')
-        start_script = _cfgget(_config, _SERVICE_SECTION, 'ExecStart')
-        stop_script = _cfgget(_config, _SERVICE_SECTION, 'ExecStop')
-        env = dict([(k, v) for k, v in _config.items(_ENVIRONMENT_SECTION)])
+        name = _cfgget(config, _UNIT_SECTION, 'Name')
+        runs_on = _parse_runs_on(_cfgget(config, _UNIT_SECTION, 'RunsOn'))
+        pre_start_script = _cfgget(config, _SERVICE_SECTION, 'ExecStartPre', '')
+        start_script = _cfgget(config, _SERVICE_SECTION, 'ExecStart')
+        stop_script = _cfgget(config, _SERVICE_SECTION, 'ExecStop')
+        env = dict(config.items(_ENVIRONMENT_SECTION))
 
-        return ConfigOpts(name, runs_on, pre_start_script, start_script,
-                stop_script, env, template_resolver)
+        return ConfigOpts(name, runs_on, pre_start_script, start_script, stop_script, env, template_resolver)
 
     def to_params(self, workdir, modules, master_template_args):
-        """Create a ConfigOptsParams object from the ConfigOpts"""
-        return ConfigOptsParams(self.name, self._runs_on, self._pre_start_script,
-                self._start_script, self._stop_script, self._env, workdir,
-                modules, master_template_args)
+        """Create a ConfigOptsParams object from the ConfigOpts instance"""
+        return ConfigOptsParams(self.name, self._runs_on, self._pre_start_script, self._start_script, 
+                                self._stop_script, self._env, workdir, modules, master_template_args)
 
     @staticmethod
     def from_params(params, template_resolver):
-        """Create a ConfigOpts from a ConfigOptsParams"""
-        return ConfigOpts(params.name, params.runs_on,
-                params.pre_start_script, params.start_script,
-                params.stop_script, params.env, template_resolver)
+        """Create a ConfigOpts instance from a ConfigOptsParams instance"""
+        return ConfigOpts(params.name, params.runs_on, params.pre_start_script, params.start_script,
+                          params.stop_script, params.env, template_resolver)
 
-    def __init__(self, name, runs_on, pre_start_script, start_script,
-            stop_script, env, template_resolver):
+    def __init__(self, name, runs_on, pre_start_script, start_script, stop_script, env, template_resolver):
         self.name = name
         self._runs_on = runs_on
         self._tr = template_resolver
@@ -498,4 +494,3 @@ def resolve_config_paths(config, dist):
         raise RuntimeError('A config or a dist must be provided')
 
     return path
-

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 from ConfigParser import NoOptionError, NoSectionError, SafeConfigParser
-from collections import Mapping
+from collections import Mapping, namedtuple
 from copy import deepcopy
 from importlib import import_module
 from os.path import join as mkpath, dirname, realpath
@@ -135,6 +135,8 @@ class PreServiceConfigOpts(object):
     Manifest file for the group of services responsible for defining service
     level configs which need to be run through the template before any services
     can begin.
+
+    aka hod.conf or hodconf.
     """
     __slots__ = ['version', 'workdir', 'config_writer', 'directories',
                  'autogen', 'modules', 'service_configs', 'service_files', 'master_env']
@@ -300,23 +302,56 @@ class ConfigOpts(object):
     Some of the slots are computed on call so that they can run on the Slave
     nodes as opposed to the Master nodes.
     """
-    def __init__(self, fileobj, template_resolver):
-        self._config = load_service_config(fileobj)
-        self.name = _cfgget(self._config, _UNIT_SECTION, 'Name')
-        self._runs_on = _parse_runs_on(_cfgget(self._config, _UNIT_SECTION, 'RunsOn'))
+
+    @staticmethod
+    def from_file(fileobj, template_resolver):
+        """Load a ConfigOpts from a configuration file."""
+        _config = load_service_config(fileobj)
+
+        name = _cfgget(_config, _UNIT_SECTION, 'Name')
+        runs_on = _parse_runs_on(_cfgget(_config, _UNIT_SECTION, 'RunsOn'))
+        pre_start_script = _cfgget(_config, _SERVICE_SECTION, 'ExecStartPre', '')
+        start_script = _cfgget(_config, _SERVICE_SECTION, 'ExecStart')
+        stop_script = _cfgget(_config, _SERVICE_SECTION, 'ExecStop')
+        env = dict([(k, v) for k, v in _config.items(_ENVIRONMENT_SECTION)])
+
+        return ConfigOpts(name, runs_on, pre_start_script, start_script,
+                stop_script, env, template_resolver)
+
+    def to_params(self, workdir, modules, master_template_args):
+        """Create a ConfigOptsParams object from the ConfigOpts"""
+        return ConfigOptsParams(self.name, self.runs_on, self.pre_start_script,
+                self.start_script, self.stop_script, self._env, workdir,
+                modules, master_template_args)
+
+    @staticmethod
+    def from_params(configopts, template_resolver):
+        """Create a ConfigOpts from a ConfigOptsParams"""
+        return ConfigOpts(configopts.name, configopts.runs_on,
+                configopts.pre_start_script, configopts.start_script,
+                configopts.stop_script, configopts.env, template_resolver)
+
+    def __init__(self, name, runs_on, pre_start_script, start_script,
+            stop_script, env, template_resolver):
+        self.name = name
+        self._runs_on = runs_on
         self._tr = template_resolver
+        self._pre_start_script = pre_start_script
+        self._start_script = start_script
+        self._stop_script = stop_script
+        self._env = env
 
     @property
     def pre_start_script(self):
-        return self._tr(_cfgget(self._config, _SERVICE_SECTION, 'ExecStartPre', ''))
+        return self._tr(self._pre_start_script)
 
     @property
     def start_script(self):
-        return self._tr(_cfgget(self._config, _SERVICE_SECTION, 'ExecStart'))
+        return self._tr(self._start_script)
 
     @property
     def stop_script(self):
-        return self._tr(_cfgget(self._config, _SERVICE_SECTION, 'ExecStop'))
+        return self._tr(self._stop_script)
 
     @property
     def workdir(self):
@@ -332,7 +367,7 @@ class ConfigOpts(object):
 
     @property
     def env(self):
-        return dict([(k, self._tr(v)) for k, v in self._config.items(_ENVIRONMENT_SECTION)])
+        return dict([(k, self._tr(v)) for k, v in self._env.items()])
 
     def __str__(self):
         return 'ConfigOpts(name=%s, runs_on=%d, pre_start_script=%s, ' \
@@ -363,6 +398,19 @@ class ConfigOpts(object):
         else:
             raise ValueError('ConfigOpts.runs_on has invalid value: %s' % self._runs_on)
 
+# Parameters to send over the network to allow slaves to construct hod.config.ConfigOpts
+# objects
+ConfigOptsParams = namedtuple('ConfigOptsParams', [
+    'name', 
+    'runs_on',
+    'pre_start_script', 
+    'start_script',
+    'stop_script', 
+    'env', 
+    'workdir', 
+    'modules', 
+    'master_template_kwargs'
+    ])
 
 def autogen_fn(name):
     """

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -149,7 +149,8 @@ class PreServiceConfigOpts(object):
         precfg = reduce(merge, precfgs)
         bad_fields = invalid_fields(precfg)
         if bad_fields:
-            raise RuntimeError("A valid configuration could not be generated from the files: %s: missing fields: %s" % (filenames, bad_fields))
+            raise RuntimeError("A valid configuration could not be generated from the files: %s: missing fields: %s" %
+                               (filenames, bad_fields))
         return precfg
 
     def __init__(self, fileobj, **kwargs):

--- a/hod/hodproc.py
+++ b/hod/hodproc.py
@@ -32,8 +32,7 @@ from os.path import join as mkpath
 from hod.mpiservice import MpiService, Task, MASTERRANK
 from hod.config.config import (PreServiceConfigOpts, ConfigOpts, 
         ConfigOptsParams, env2str, service_config_fn, write_service_config,
-        preserviceconfigopts_from_file_list, parse_comma_delim_list,
-        resolve_config_paths, RUNS_ON_MASTER)
+        parse_comma_delim_list, resolve_config_paths, RUNS_ON_MASTER)
 from hod.config.template import (TemplateRegistry, TemplateResolver,
         register_templates)
 from hod.work.config_service import ConfiguredService
@@ -80,7 +79,7 @@ def load_hod_config(filenames, workdir, modules):
     '''
     m_config_filenames = parse_comma_delim_list(filenames)
     _log.info('Loading "%s" manifest config', m_config_filenames)
-    m_config = preserviceconfigopts_from_file_list(m_config_filenames,
+    m_config = PreServiceConfigOpts.from_file_list(m_config_filenames,
             workdir=workdir, modules=modules)
     _log.debug('Loaded manifest config: %s', str(m_config))
     return m_config
@@ -128,8 +127,8 @@ class ConfiguredMaster(MpiService):
 
         if hasattr(self.options, 'script') and self.options.script is not None:
             script = self.options.script
-            # How can we test this?
-            config = ConfigOpts(script, RUNS_ON_MASTER, '', script, 'qdel $PBS_JOBID', master_env, resolver)
+            # TODO: How can we test this?
+            config = ConfigOpts(script, RUNS_ON_MASTER, '', script + '; qdel $PBS_JOBID', '', master_env, resolver)
             ranks_to_run = config.runs_on(MASTERRANK, range(self.size))
             cfg_opts = config.to_params(m_config.workdir, m_config.modules, master_template_args)
             self.tasks.append(Task(ConfiguredService, config.name, ranks_to_run, cfg_opts, master_env))

--- a/hod/hodproc.py
+++ b/hod/hodproc.py
@@ -126,9 +126,9 @@ class ConfiguredMaster(MpiService):
             self.tasks.append(Task(ConfiguredService, config.name, ranks_to_run, cfg_opts, master_env))
 
         if hasattr(self.options, 'script') and self.options.script is not None:
-            script = self.options.script
+            script = self.options.script + '; qdel $PBS_JOBID'
             # TODO: How can we test this?
-            config = ConfigOpts(script, RUNS_ON_MASTER, '', script + '; qdel $PBS_JOBID', '', master_env, resolver)
+            config = ConfigOpts(script, RUNS_ON_MASTER, '', script, '', master_env, resolver)
             ranks_to_run = config.runs_on(MASTERRANK, range(self.size))
             cfg_opts = config.to_params(m_config.workdir, m_config.modules, master_template_args)
             self.tasks.append(Task(ConfiguredService, config.name, ranks_to_run, cfg_opts, master_env))

--- a/hod/local.py
+++ b/hod/local.py
@@ -93,6 +93,7 @@ class LocalOptions(GeneralOption):
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
         opts.update({
             'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
+            'script': ("Script to run on the cluster", "string", "store", None),
         })
         descr = ["Local configuration", "Configuration options for the 'genconfig' subcommand"]
 

--- a/hod/main.py
+++ b/hod/main.py
@@ -32,11 +32,12 @@ Hanythingondemand main program.
 import sys
 
 import hod
-from hod.subcommands import connect, create, dists, genconfig, helptemplate, listcmd
+from hod.subcommands import batch, connect, create, dists, genconfig, helptemplate, listcmd
 
 
 SUBCOMMANDS = [
     create.CreateSubCommand,
+    batch.BatchSubCommand,
     listcmd.ListSubCommand,
     dists.DistsSubCommand,
     helptemplate.HelpTemplateSubCommand,
@@ -74,7 +75,7 @@ def main(args):
         return subcmd.run(args)
 
     elif len([arg for arg in args if not arg.startswith('-')]) > 1:
-        sys.stderr.write("ERROR: No known subcommand specified")
+        sys.stderr.write("ERROR: No known subcommand specified\n")
         sys.stderr.write(usage())
         return 1
     else:

--- a/hod/options.py
+++ b/hod/options.py
@@ -40,6 +40,15 @@ GENERAL_HOD_OPTIONS = {
     'workdir': ("Working directory", 'string', 'store', None),
 }
 
+RESOURCE_MANAGER_OPTIONS = {
+    'walltime': ("Job walltime in hours", 'float', 'store', 48, 'l'),
+    'nodes': ("Full nodes for the job", "int", "store", 5, "n"),
+    'ppn': ("Processors per node (-1=full node)", "int", "store", -1),
+    'mail': ("When to send mail (b=begin, e=end, a=abort)", "string", "extend", [], "m"),
+    'mailothers': ("Other email adresses to send mail to", "string", "extend", [], "M"),
+    'name': ("Job name", "string", "store", "HanythingOnDemand_job", "N"),
+    'queue': ("Queue name (empty string is default queue)", "string", "store", "", "q"),
+}
 
 _log = fancylogger.getLogger('create', fname=False)
 

--- a/hod/options.py
+++ b/hod/options.py
@@ -46,7 +46,6 @@ RESOURCE_MANAGER_OPTIONS = {
     'ppn': ("Processors per node (-1=full node)", "int", "store", -1),
     'mail': ("When to send mail (b=begin, e=end, a=abort)", "string", "extend", [], "m"),
     'mailothers': ("Other email adresses to send mail to", "string", "extend", [], "M"),
-    'name': ("Job name", "string", "store", "HanythingOnDemand_job", "N"),
     'queue': ("Queue name (empty string is default queue)", "string", "store", "", "q"),
 }
 

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -56,8 +56,7 @@ class HodJob(Job):
 
         self.name_suffix = 'HOD'  # suffixed name, to lookup later
         options_dict = self.options.dict_by_prefix()
-        options_dict['job']['name'] = "%s_%s" % (options_dict['job']['name'],
-                                                self.name_suffix)
+        options_dict['job']['name'] = "%s_%s" % (options_dict['job']['name'], self.name_suffix)
         self.type = self.type_class(options_dict['job'])
 
         # all jobqueries are filtered on this suffix

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -58,14 +58,14 @@ class HodJob(Job):
         self.name_prefix = 'HOD'
         options_dict = self.options.dict_by_prefix()
         label = 'job'
-        if 'label' in options_dict and options_dict['label'] is not None:
-            label = options_dict['label']
+        if 'label' in options_dict[''] and not options_dict['']['label'] is None:
+            label = options_dict['']['label']
         options_dict['job']['name'] = "%s_%s" % (self.name_prefix, label)
 
         self.type = self.type_class(options_dict['job'])
 
         # all jobqueries are filtered on this suffix
-        self.type.job_filter = {'Job_Name': '%s$' % self.name_prefix}
+        self.type.job_filter = {'Job_Name': '^%s' % self.name_prefix}
 
         self.run_in_cwd = True
 

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -35,7 +35,7 @@ from hod.rmscheduler.job import Job
 from hod.rmscheduler.rm_pbs import Pbs
 from hod.rmscheduler.resourcemanagerscheduler import ResourceManagerScheduler
 from hod.config.config import (parse_comma_delim_list,
-        preserviceconfigopts_from_file_list, resolve_config_paths)
+        PreServiceConfigOpts, resolve_config_paths)
 
 
 class HodJob(Job):
@@ -142,7 +142,7 @@ class PbsHodJob(MympirunHod):
         self.log.info('Loading "%s" manifest config', config_filenames)
         # If the user mistypes the --dist argument (e.g. Haddoop-...) then this will
         # raise; TODO: cleanup the error reporting. 
-        precfg = preserviceconfigopts_from_file_list(config_filenames, workdir=options.options.workdir)
+        precfg = PreServiceConfigOpts.from_file_list(config_filenames, workdir=options.options.workdir)
         for module in precfg.modules:
             self.log.debug("Adding '%s' module to startup script.", module)
             self.modules.append(module)

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -54,13 +54,18 @@ class HodJob(Job):
 
         self.set_type_class()
 
-        self.name_suffix = 'HOD'  # suffixed name, to lookup later
+        # HOD_<label> if label is given; HOD_job otherwise.
+        self.name_prefix = 'HOD'
         options_dict = self.options.dict_by_prefix()
-        options_dict['job']['name'] = "%s_%s" % (options_dict['job']['name'], self.name_suffix)
+        label = 'job'
+        if 'label' in options_dict and options_dict['label'] is not None:
+            label = options_dict['label']
+        options_dict['job']['name'] = "%s_%s" % (self.name_prefix, label)
+
         self.type = self.type_class(options_dict['job'])
 
         # all jobqueries are filtered on this suffix
-        self.type.job_filter = {'Job_Name': '%s$' % self.name_suffix}
+        self.type.job_filter = {'Job_Name': '%s$' % self.name_prefix}
 
         self.run_in_cwd = True
 

--- a/hod/rmscheduler/rm_pbs.py
+++ b/hod/rmscheduler/rm_pbs.py
@@ -201,9 +201,11 @@ class Pbs(ResourceManagerScheduler):
                     continue
                 res.append(h)
             return res[:num]
+
         ehosts = [get_uniq_hosts(x.get('exec_host', '')) for x in state]
 
         self.log.debug("Jobid  %s jid %s state %s ehosts %s (%s)", jobid, jid, jstate, ehosts, state)
+
         def _first_or_blank(x):
             '''Only use first node (don't use [0], job in Q have empty list'''
             return '' if len(x) == 0 else x[0]

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -96,6 +96,8 @@ class BatchSubCommand(SubCommand):
         try:
             j = PbsHodJob(optparser)
             j.run()
+            jobs = j.state()
+            print "Jobs submitted: %s" % [str(j) for j in jobs]
             return 0
         except StandardError as e:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# #
+# Copyright 2009-2015 Ghent University
+#
+# This file is part of hanythingondemand
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/hanythingondemand
+#
+# hanythingondemand is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# hanythingondemand is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hanythingondemand. If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Generate a PBS job script using pbs_python. Will use mympirun to get the cluster
+all started, run a job, and tear down the cluster when it's done.
+
+@author: Stijn De Weirdt (Universiteit Gent)
+@author: Ewan Higgs (Universiteit Gent)
+"""
+import copy
+import sys
+
+from vsc.utils import fancylogger
+from vsc.utils.generaloption import GeneralOption
+
+from hod import VERSION as HOD_VERSION
+from hod.options import GENERAL_HOD_OPTIONS, validate_pbs_option
+from hod.rmscheduler.hodjob import PbsHodJob
+from hod.subcommands.subcommand import SubCommand
+from hod.subcommands.create import CreateOptions
+
+_log = fancylogger.getLogger('batch', fname=False)
+
+class BatchOptions(GeneralOption):
+    VERSION = HOD_VERSION
+
+    def config_options(self):
+        """Add general configuration options."""
+        opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
+        opts['script'] = ("Script to run on the cluster", "string", "store", None )
+        descr = ["Batch configuration", "Configuration options for the 'batch' subcommand"]
+
+        self.log.debug("Add config option parser descr %s opts %s", descr, opts)
+        self.add_group_parser(opts, descr)
+
+
+class BatchSubCommand(SubCommand):
+    """Implementation of 'create' subcommand."""
+    CMD = 'Batch'
+    EXAMPLE = "--hodconf=<hod.conf file> --workdir=<working directory> --script=<jobscript>"
+    HELP = "Submit a job to spawn a cluster on a PBS job controller, run a job script, and tear down the cluster when it's done"
+
+    def run(self, args):
+        """Run 'batch' subcommand."""
+        optparser = BatchOptions(go_args=args, envvar_prefix=self.envvar_prefix, usage=self.usage_txt)
+        if not validate_pbs_option(optparser):
+            sys.stderr.write('Missing config options. Exiting.\n')
+            return 1
+
+        if optparser.options.script is None:
+            sys.stderr.write('Missing script. Exiting.\n')
+            return 1
+
+        try:
+            # Don't use pbshodjob here; make a different type.
+            j = PbsHodJob(optparser)
+            j.run()
+            return 0
+        except StandardError as e:
+            fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
+            fancylogger.logToScreen(enable=True)
+            _log.raiseException(e.message)

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -27,7 +27,7 @@
 Generate a PBS job script using pbs_python. Will use mympirun to get the cluster
 all started, run a job, and tear down the cluster when it's done.
 
-@author: Stijn De Weirdt (Universiteit Gent)
+@author: Kenneth Hoste (Universiteit Gent)
 @author: Ewan Higgs (Universiteit Gent)
 """
 import copy
@@ -70,14 +70,14 @@ class BatchOptions(GeneralOption):
         opts.update({
             'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
         })
-        descr = ["Create configuration", "Configuration options for the 'batch' subcommand"]
+        descr = ["Batch job creation configuration", "Configuration options for the 'batch' subcommand"]
 
         self.log.debug("Add config option parser descr %s opts %s", descr, opts)
         self.add_group_parser(opts, descr)
 
 
 class BatchSubCommand(SubCommand):
-    """Implementation of 'create' subcommand."""
+    """Implementation of 'batch' subcommand."""
     CMD = 'batch'
     EXAMPLE = "--hodconf=<hod.conf file> --workdir=<working directory> --script=<jobscript>"
     HELP = "Submit a job to spawn a cluster on a PBS job controller, run a job script, and tear down the cluster when it's done"

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -36,7 +36,7 @@ from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 from hod import VERSION as HOD_VERSION
-from hod.options import GENERAL_HOD_OPTIONS, validate_pbs_option
+from hod.options import GENERAL_HOD_OPTIONS, RESOURCE_MANAGER_OPTIONS, validate_pbs_option
 from hod.rmscheduler.hodjob import PbsHodJob
 from hod.subcommands.subcommand import SubCommand
 
@@ -50,15 +50,7 @@ class CreateOptions(GeneralOption):
 
     def resource_manager_options(self):
         """Add configuration options for job being submitted."""
-        opts = {
-            'walltime': ("Job walltime in hours", 'float', 'store', 48, 'l'),
-            'nodes': ("Full nodes for the job", "int", "store", 5, "n"),
-            'ppn': ("Processors per node (-1=full node)", "int", "store", -1),
-            'mail': ("When to send mail (b=begin, e=end, a=abort)", "string", "extend", [], "m"),
-            'mailothers': ("Other email adresses to send mail to", "string", "extend", [], "M"),
-            'name': ("Job name", "string", "store", "HanythingOnDemand_job", "N"),
-            'queue': ("Queue name (empty string is default queue)", "string", "store", "", "q"),
-        }
+        opts = copy.deepcopy(RESOURCE_MANAGER_OPTIONS)
         descr = ["Resource manager / Scheduler",
                  "Provide resource manager/scheduler related options (eg number of nodes)"]
         prefix = 'job'

--- a/hod/subcommands/helptemplate.py
+++ b/hod/subcommands/helptemplate.py
@@ -44,9 +44,8 @@ class HelpTemplateOptions(GeneralOption):
 
 def mk_registry():
     """Make a TemplateRegistry and register basic items"""
-    config_opts = ConfigOptsParams('svc-name', 'MASTER', 'ExecPreStart',
-            'ExecStart', 'ExecStop', dict(), workdir='WORKDIR',
-        modules=['MODULES'], master_template_kwargs=[])
+    config_opts = ConfigOptsParams('svc-name', 'MASTER', 'ExecPreStart', 'ExecStart', 'ExecStop',
+                                   dict(), workdir='WORKDIR', modules=['MODULES'], master_template_kwargs=[])
     reg = hct.TemplateRegistry()
     hct.register_templates(reg, config_opts)
     master_template_kwargs = master_template_opts(reg.fields.values())

--- a/hod/subcommands/helptemplate.py
+++ b/hod/subcommands/helptemplate.py
@@ -28,13 +28,13 @@ Print out template parameters used by hod.
 @author: Ewan Higgs (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-import copy
 from vsc.utils.generaloption import GeneralOption
 
 import hod.config.template as hct
 from hod import VERSION as HOD_VERSION
 from hod.subcommands.subcommand import SubCommand
-from hod.mpiservice import ConfigOptsParams, master_template_opts
+from hod.mpiservice import master_template_opts
+from hod.config.config import ConfigOptsParams
 
 
 class HelpTemplateOptions(GeneralOption):
@@ -44,7 +44,8 @@ class HelpTemplateOptions(GeneralOption):
 
 def mk_registry():
     """Make a TemplateRegistry and register basic items"""
-    config_opts = ConfigOptsParams(filename='hod.conf', workdir='WORKDIR',
+    config_opts = ConfigOptsParams('svc-name', 'MASTER', 'ExecPreStart',
+            'ExecStart', 'ExecStop', dict(), workdir='WORKDIR',
         modules=['MODULES'], master_template_kwargs=[])
     reg = hct.TemplateRegistry()
     hct.register_templates(reg, config_opts)

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -33,6 +33,7 @@ from mock import patch
 from os.path import basename
 from cStringIO import StringIO
 from cPickle import dumps, loads
+from ConfigParser import NoOptionError
 
 import hod.config.config as hcc
 import hod.config.template as hct
@@ -341,7 +342,6 @@ ExecStop=stopper
 SOME_ENV=123""")
         cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
         cfgparams = cfg.to_params('workdir', 'modules', dict(master='template_args'))
-        print cfgparams
         remade_cfg = loads(dumps(cfgparams))
         self.assertEqual(cfgparams.name, remade_cfg.name)
         self.assertEqual(cfgparams.start_script, remade_cfg.start_script)
@@ -394,6 +394,7 @@ SOME_ENV=123""")
         self.assertEqual(hcc._cfgget(cfg, 'Service', 'daemon', 'default', daemon='override'), 'override')
         self.assertEqual(hcc._cfgget(cfg, 'Service', 'daemon2', 'notfound'), 'notfound')
         self.assertEqual(hcc._cfgget(cfg, 'Service', 'daemon2', 'notfound', daemon2='override'), 'override')
+        self.assertRaises(NoOptionError, hcc._cfgget, cfg, 'Service', 'angel')
 
 
     def test_resolve_dist_path(self):

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -327,6 +327,27 @@ SOME_ENV=123""")
         self.assertEqual(cfg.start_script, remade_cfg.start_script)
         self.assertEqual(cfg.stop_script, remade_cfg.stop_script)
 
+    def test_ConfigOptsParams_pickles(self):
+        config = StringIO("""
+[Unit]
+Name=testconfig
+RunsOn=master
+
+[Service]
+ExecStart=starter
+ExecStop=stopper
+
+[Environment]
+SOME_ENV=123""")
+        cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
+        cfgparams = cfg.to_params('workdir', 'modules', dict(master='template_args'))
+        print cfgparams
+        remade_cfg = loads(dumps(cfgparams))
+        self.assertEqual(cfgparams.name, remade_cfg.name)
+        self.assertEqual(cfgparams.start_script, remade_cfg.start_script)
+        self.assertEqual(cfgparams.stop_script, remade_cfg.stop_script)
+
+
     def test_ConfigOpts_ConfigParser_replacement(self):
         config = StringIO("""
 [Unit]
@@ -343,6 +364,11 @@ SOME_ENV=123""")
         cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
         self.assertEqual(cfg.start_script, '$MYPATH/starter')
         self.assertEqual(cfg.stop_script, '$MYPATH/stopper')
+
+        params = cfg.to_params(workdir='', modules='', master_template_args=dict())
+        cfg2 = hcc.ConfigOpts.from_params(params, hct.TemplateResolver(workdir=''))
+        self.assertEqual(cfg2.start_script, '$MYPATH/starter')
+        self.assertEqual(cfg2.stop_script, '$MYPATH/stopper')
 
     def test_env2str(self):
         env = dict(PATH="/usr/bin", LD_LIBRARY_PATH="something with spaces")

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -234,7 +234,7 @@ ExecStop=stopper
 
 [Environment]
 SOME_ENV=123""")
-        cfg = hcc.ConfigOpts(config, hct.TemplateResolver(workdir=''))
+        cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
         self.assertEqual(cfg.name, 'testconfig')
         self.assertEqual(cfg._runs_on, hcc.RUNS_ON_MASTER)
         self.assertEqual(cfg.runs_on(0, [0, 1, 2, 3]), [0])
@@ -257,7 +257,7 @@ ExecStop=stopper
 
 [Environment]
 SOME_ENV=123""")
-        cfg = hcc.ConfigOpts(config, hct.TemplateResolver(workdir=''))
+        cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
         self.assertEqual(cfg.name, 'testconfig')
         self.assertEqual(cfg._runs_on, hcc.RUNS_ON_SLAVE)
         self.assertEqual(cfg.runs_on(0, [0, 1, 2]), [1, 2])
@@ -275,7 +275,7 @@ ExecStop=stopper
 
 [Environment]
 SOME_ENV=123""")
-        cfg = hcc.ConfigOpts(config, hct.TemplateResolver(workdir=''))
+        cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
         self.assertEqual(cfg.name, 'testconfig')
         self.assertEqual(cfg._runs_on, hcc.RUNS_ON_ALL)
         self.assertEqual(cfg.runs_on(0, [0, 1, 2]), [0, 1, 2])
@@ -304,7 +304,7 @@ ExecStop=$BINDIR/stopper
 [Environment]
 SOME_ENV=123""")
         with patch('hod.config.template.os.environ', dict(BINDIR='/usr/bin')):
-            cfg = hcc.ConfigOpts(config, hct.TemplateResolver(workdir=''))
+            cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
             self.assertEqual(cfg.start_script, '/usr/bin/starter')
             self.assertEqual(cfg.stop_script, '/usr/bin/stopper')
 
@@ -321,7 +321,7 @@ ExecStop=stopper
 
 [Environment]
 SOME_ENV=123""")
-        cfg = hcc.ConfigOpts(config, hct.TemplateResolver(workdir=''))
+        cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
         remade_cfg = loads(dumps(cfg))
         self.assertEqual(cfg.name, remade_cfg.name)
         self.assertEqual(cfg.start_script, remade_cfg.start_script)
@@ -340,7 +340,7 @@ ExecStop=%(daemon)s/stopper
 
 [Environment]
 SOME_ENV=123""")
-        cfg = hcc.ConfigOpts(config, hct.TemplateResolver(workdir=''))
+        cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
         self.assertEqual(cfg.start_script, '$MYPATH/starter')
         self.assertEqual(cfg.stop_script, '$MYPATH/stopper')
 

--- a/test/unit/subcommands/test_subcommands_batch.py
+++ b/test/unit/subcommands/test_subcommands_batch.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# #
+# Copyright 2009-2015 Ghent University
+#
+# This file is part of hanythingondemand
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/hanythingondemand
+#
+# hanythingondemand is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# hanythingondemand is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hanythingondemand. If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+@author: Ewan Higgs (Universiteit Gent)
+"""
+
+import unittest
+import pytest
+
+from hod.subcommands.batch import BatchSubCommand
+
+from mock import patch
+
+class TestBatchSubCommand(unittest.TestCase):
+    @pytest.mark.xfail(reason="Requires easybuild environment")
+    def test_run_no_args(self):
+        with patch('hod.subcommands.batch.PbsHodJob'):
+            app = BatchSubCommand()
+            self.assertRaises(ValueError, app.run, [])
+
+    @pytest.mark.xfail(reason="Requires easybuild environment")
+    def test_run_with_hodconf_and_no_script(self):
+        with patch('hod.subcommands.batch.PbsHodJob'):
+            app = BatchSubCommand()
+            self.assertEqual(1, app.run(['--hodconf=hod.conf', '--workdir=workdir']))
+
+    def test_run_fails_with_dist_and_no_script(self):
+        with patch('hod.subcommands.batch.PbsHodJob'):
+            app = BatchSubCommand()
+            self.assertEqual(1, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir']))
+
+    def test_run_with_hodconf(self):
+        with patch('hod.subcommands.batch.PbsHodJob'):
+            app = BatchSubCommand()
+            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--script=some-script.sh']))
+
+
+    def test_run_with_dist(self):
+        with patch('hod.subcommands.batch.PbsHodJob'):
+            app = BatchSubCommand()
+            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--script=some-script.sh']))
+
+
+    def test_run_fails_with_config_and_dist_arg(self):
+        with patch('hod.subcommands.batch.PbsHodJob'):
+            app = BatchSubCommand()
+            self.assertEqual(1, app.run(['--hodconf=hod.conf', '--dist=Hadoop-2.3.0', '--workdir=workdir']))
+
+    def test_usage(self):
+        app = BatchSubCommand()
+        usage = app.usage()
+        self.assertTrue(isinstance(usage, basestring))

--- a/test/unit/work/test_work_config_service.py
+++ b/test/unit/work/test_work_config_service.py
@@ -59,29 +59,29 @@ class TestHodWorkConfiguredService(unittest.TestCase):
 
     def test_ConfiguredService_init(self):
         '''Test creation of the ConfiguredService'''
-        cfg = hcc.ConfigOpts(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
+        cfg = hcc.ConfigOpts.from_file(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
         cs = hwc.ConfiguredService(cfg)
 
     def test_ConfiguredService_pre_start_work_service(self):
         '''Test ConfiguredService pre_start method'''
-        cfg = hcc.ConfigOpts(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
+        cfg = hcc.ConfigOpts.from_file(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
         cs = hwc.ConfiguredService(cfg)
         cs.pre_start_work_service()
 
     def test_ConfiguredService_start_work_service(self):
         '''Test ConfiguredService start method'''
-        cfg = hcc.ConfigOpts(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
+        cfg = hcc.ConfigOpts.from_file(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
         cs = hwc.ConfiguredService(cfg)
         cs.start_work_service()
 
     def test_ConfiguredService_stop_work_service(self):
         '''Test ConfiguredService stop method'''
-        cfg = hcc.ConfigOpts(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
+        cfg = hcc.ConfigOpts.from_file(_mk_master_config(), hct.TemplateResolver(workdir='/tmp'))
         cs = hwc.ConfiguredService(cfg)
         cs.stop_work_service()
 
     def test_ConfiguredService_prepare_work_cfg(self):
-        cfg = hcc.ConfigOpts(_mk_slave_config(), hct.TemplateResolver(workdir='/tmp'))
+        cfg = hcc.ConfigOpts.from_file(_mk_slave_config(), hct.TemplateResolver(workdir='/tmp'))
         cs = hwc.ConfiguredService(cfg)
         with patch('hod.work.config_service.os.makedirs', side_effect=lambda *args: None):
             with patch('hod.config.config.mklocalworkdir', side_effect=lambda *args: '/tmp/node1234.awesomeuser.123'):


### PR DESCRIPTION
This implements #57.

Usage example:

```
$ hod batch --dist Hadoop-2.5.0-cdh5.3.1-native --workdir=$MYSCRATCH/hod -n2 --script=$MYSCRATCH/wordcount/wordcount.sh
```

This works rejigs the `ConfigOptsParams` to hold all the params needed to make a `ConfigOpts` (aside from the template resolver). Moving between `ConfigOpts` and `ConfigOptsParams` use `staticmethod` functions instead of standalone functions.

The batch work is done by making the `script` option into a `ConfigOpts` object that has no config file and uses `start_script` (`ExecStart` in the configfile which we're not using) is the script but suffixed with `; qdel $PBS_JOBID` which basically just tears down the cluster.