### PR TITLE
add guard around mpi4py import in hod.local

### DIFF
--- a/hod/local.py
+++ b/hod/local.py
@@ -33,7 +33,6 @@ import os
 import random
 import string
 import sys
-from mpi4py import MPI
 
 from hod import VERSION as HOD_VERSION
 
@@ -44,6 +43,22 @@ from hod.config.config import resolve_config_paths
 from hod.hodproc import ConfiguredSlave, ConfiguredMaster, load_hod_config
 from hod.mpiservice import MASTERRANK, run_tasks, setup_tasks
 from hod.options import GENERAL_HOD_OPTIONS
+
+try:
+    from mpi4py import MPI
+    # mpi4py is available, no need guard against import errors
+    def mpi4py_is_available(fn):
+        """No-op decorator."""
+        return fn
+
+except ImportError as err:
+    def mpi4py_is_available(_):
+        """Decorator which raises an ImportError because mpi4py is not available."""
+        def fail(*args, **kwargs):
+            """Raise ImportError since mpi4py is not available."""
+            raise ImportError("%s; is there an environment module providing MPI support loaded?" % err)
+
+        return fail
 
 
 CLUSTER_ENV_TEMPLATE = """
@@ -178,6 +193,7 @@ def save_cluster_info(cluster_info):
         _log.error("Failed to write cluster info files: %s", err)
 
 
+@mpi4py_is_available
 def main(args):
     """Run HOD cluster."""
     optparser = LocalOptions(go_args=args)


### PR DESCRIPTION
without this, `create --help` doesn't work unless `mpi4py` is available (since it imports from `hod.local`), which is kinda stupid