### PR TITLE
add support for --hod-module + some refactoring + docs update

### DIFF
--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -108,11 +108,10 @@ Configuration options for ``hod create``
 ``hod create --hod-module <module name>``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*required*
+**must be specified**
 
-Specify the ``hanythingondemand`` module that must be loaded in the job that is submitted for the HOD cluster.
-
-Can also be specified via ``$HOD_CREATE_HOD_MODULE``.
+Specify the ``hanythingondemand`` module that must be loaded in the job that is submitted for the HOD cluster;
+can also be specified via ``$HOD_CREATE_HOD_MODULE``.
 
 
 .. _cmdline_create_options_workdir:
@@ -120,11 +119,9 @@ Can also be specified via ``$HOD_CREATE_HOD_MODULE``.
 ``hod create --workdir <path>``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*required*
+**must be specified**
 
-Specify the top-level working directory to use.
-
-Can also be specified via ``$HOD_CREATE_WORKDIR``.
+Specify the top-level working directory to use; can also be specified via ``$HOD_CREATE_WORKDIR``.
 
 
 .. _cmdline_create_options_hodconf:
@@ -132,11 +129,9 @@ Can also be specified via ``$HOD_CREATE_WORKDIR``.
 ``hod create --hodconf <path>``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*either* ``--dist`` *or this must be specified*
+**either** ``--dist`` **or this must be specified**
 
-Specify location of cluster configuration file.
-
-Can also be specified via ``$HOD_CREATE_HODCONF``.
+Specify location of cluster configuration file; can also be specified via ``$HOD_CREATE_HODCONF``.
 
 
 .. _cmdline_create_options_dist:
@@ -144,11 +139,10 @@ Can also be specified via ``$HOD_CREATE_HODCONF``.
 ``hod create --dist <dist>``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*either* ``--hodconf`` *or this must be specified*
+**either** ``--hodconf`` **or this must be specified**
 
-Specify one of the included cluster configuration file to be used (see also :ref:`cmdline_dists`).
-
-Can also be specified via ``$HOD_CREATE_DIST``.
+Specify one of the included cluster configuration file to be used (see also :ref:`cmdline_dists`);
+can also be specified via ``$HOD_CREATE_DIST``.
 
 
 .. _cmdline_create_options_label:
@@ -156,11 +150,10 @@ Can also be specified via ``$HOD_CREATE_DIST``.
 ``hod create --label <label>``
 ++++++++++++++++++++++++++++++
 
-Specify label for this cluster. If not label is specified, the job ID will be used as a label.
+Specify label for this cluster. If not label is specified, the job ID will be used as a label;
+can also be specified via ``$HOD_CREATE_LABEL``.
 
 The label can be used to later connect to the cluster while it is running (see :ref:`cmdline_connect`).
-
-Can also be specified via ``$HOD_CREATE_LABEL``.
 
 
 .. _cmdline_create_options_modules:
@@ -182,9 +175,7 @@ Can also be specified via ``$HOD_CREATE_MODULES``.
 ++++++++++++++++++++++
 
 The resources being requested for the job that is submitted can be controlled via the available ``--job`` options,
-see :ref:`cmdline_job_options`.
-
-Can also be specified via ``$HOD_CREATE_JOB_*``.
+see :ref:`cmdline_job_options`; can also be specified via ``$HOD_CREATE_JOB_*``.
 
 
 .. _cmdline_batch:
@@ -194,10 +185,11 @@ Can also be specified via ``$HOD_CREATE_JOB_*``.
 
 Create a cluster and run the script. Upon completion of the script, the cluster will be stopped.
 
-All configuration options supported for ``create`` are also supported for ``batch``, see :ref:`cmdline_create_options`.
-When used with ``batch``, they can also be specified via ``$HOD_BATCH_*``.
+Next to ``--script`` (which is mandatory with ``batch``), all configuration options supported for ``create`` are
+also supported for ``batch``, see :ref:`cmdline_create_options`.
+When used with ``batch``, these options can also be specified via ``$HOD_BATCH_*``.
 
-.. note:: `--hod-module``, ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
+.. note:: ``--hod-module``, ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
 
 
 .. _cmdline_list:
@@ -234,6 +226,8 @@ Print the values for the configuration templates based on the current machine.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Generate hanythingondemand cluster configuration files to the working directory for diagnostic purposes.
+
+The working directory can be specified using ``--workdir`` or via ``$HOD_GENCONFIG_WORKDIR``.
 
 
 .. _cmdline_connect:

--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -95,7 +95,7 @@ Create a hanythingondemand cluster, with the specified label (optional) and clus
 
 The configuration file can be a filepath, or one of the included cluster configuration files (see :ref:`cmdline_dists`).
 
-.. note:: ``--hod-module``, ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
+.. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
 
 
 .. _cmdline_create_options:
@@ -189,7 +189,7 @@ Next to ``--script`` (which is mandatory with ``batch``), all configuration opti
 also supported for ``batch``, see :ref:`cmdline_create_options`.
 When used with ``batch``, these options can also be specified via ``$HOD_BATCH_*``.
 
-.. note:: ``--hod-module``, ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
+.. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
 
 
 .. _cmdline_list:

--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -37,9 +37,8 @@ Running ``hod`` without arguments is equivalent to ``hod --help``, and results i
 
 .. _cmdline_hod_options:
 
-Configuration options for ``hod``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+General ``hod`` command line options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. _cmdline_hod_help:
 
@@ -48,27 +47,6 @@ Configuration options for ``hod``
 
 Print usage information and supported subcommands along with a short help message for each of them, or usage information
 and available options for the specified subcommand.
-
-``hod --hodconf <path>``
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Specify location of cluster configuration file.
-
-Can also be specified using ``$HOD_HODCONF``.
-
-``hod --dist <dist label>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Specify one of the included cluster configuration file to be used (see also :ref:`cmdline_dists`).
-
-Can also be specified using ``$HOD_DIST``.
-
-``hod --workdir <path>``
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Specify the top-level working directory to use.
-
-Can also be specified using ``$HOD_WORKDIR``.
 
 
 .. .. _cmdline_hod_scheduler:
@@ -117,12 +95,61 @@ Create a hanythingondemand cluster, with the specified label (optional) and clus
 
 The configuration file can be a filepath, or one of the included cluster configuration files (see :ref:`cmdline_dists`).
 
-.. note:: ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
+.. note:: ``--hod-module``, ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
+
 
 .. _cmdline_create_options:
 
 Configuration options for ``hod create``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _cmdline_create_options_hod_module:
+
+``hod create --hod-module <module name>``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*required*
+
+Specify the ``hanythingondemand`` module that must be loaded in the job that is submitted for the HOD cluster.
+
+Can also be specified via ``$HOD_CREATE_HOD_MODULE``.
+
+
+.. _cmdline_create_options_workdir:
+
+``hod create --workdir <path>``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*required*
+
+Specify the top-level working directory to use.
+
+Can also be specified via ``$HOD_CREATE_WORKDIR``.
+
+
+.. _cmdline_create_options_hodconf:
+
+``hod create --hodconf <path>``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*either* ``--dist`` *or this must be specified*
+
+Specify location of cluster configuration file.
+
+Can also be specified via ``$HOD_CREATE_HODCONF``.
+
+
+.. _cmdline_create_options_dist:
+
+``hod create --dist <dist>``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*either* ``--hodconf`` *or this must be specified*
+
+Specify one of the included cluster configuration file to be used (see also :ref:`cmdline_dists`).
+
+Can also be specified via ``$HOD_CREATE_DIST``.
+
 
 .. _cmdline_create_options_label:
 
@@ -132,6 +159,9 @@ Configuration options for ``hod create``
 Specify label for this cluster. If not label is specified, the job ID will be used as a label.
 
 The label can be used to later connect to the cluster while it is running (see :ref:`cmdline_connect`).
+
+Can also be specified via ``$HOD_CREATE_LABEL``.
+
 
 .. _cmdline_create_options_modules:
 
@@ -143,6 +173,9 @@ the cluster requires a particular module, it should be added with this option.
 For example, if an IPython notebook plans to use Python modules on the worker
 kernels (or through Spark) they will need to be added here.
 
+Can also be specified via ``$HOD_CREATE_MODULES``.
+
+
 .. _cmdline_create_options_job:
 
 ``hod create --job-*``
@@ -151,6 +184,9 @@ kernels (or through Spark) they will need to be added here.
 The resources being requested for the job that is submitted can be controlled via the available ``--job`` options,
 see :ref:`cmdline_job_options`.
 
+Can also be specified via ``$HOD_CREATE_JOB_*``.
+
+
 .. _cmdline_batch:
 
 ``hod batch --script=<script-name>``
@@ -158,38 +194,10 @@ see :ref:`cmdline_job_options`.
 
 Create a cluster and run the script. Upon completion of the script, the cluster will be stopped.
 
-.. note:: ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
+All configuration options supported for ``create`` are also supported for ``batch``, see :ref:`cmdline_create_options`.
+When used with ``batch``, they can also be specified via ``$HOD_BATCH_*``.
 
-Configuration options for ``hod batch``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _cmdline_batch_options_label:
-
-``hod batch --label <label>``
-+++++++++++++++++++++++++++++
-
-Specify label for this cluster. If not label is specified, the job ID will be used as a label.
-
-The label can be used to later connect to the cluster while it is running (see :ref:`cmdline_connect`).
-
-.. _cmdline_batch_options_job:
-
-``hod batch --job-*``
-++++++++++++++++++++++
-
-The resources being requested for the job that is submitted can be controlled via the available ``--job`` options.
-
-See :ref:`cmdline_job_options`.
-
-
-.. _cmdline_batch_options_modules:
-
-``hod batch --modules <module names>``
-++++++++++++++++++++++++++++++++++++++
-
-This acts the same as ``--modules`` for the ``create`` subcommand.
-
-See :ref:`cmdline_create_options_modules`
+.. note:: `--hod-module``, ``--workdir`` *and* either ``--hodconf`` or ``--dist`` must be specified.
 
 
 .. _cmdline_list:

--- a/hod/node/node.py
+++ b/hod/node/node.py
@@ -29,8 +29,6 @@ Network utilities
 @author: Ewan Higgs (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-import netifaces
-import netaddr
 import re
 import os
 import socket
@@ -41,17 +39,49 @@ from vsc.utils.affinity import sched_getaffinity
 
 from hod.commands.command import ULimit
 
+try:
+    import netifaces
+    def netifaces_is_available(fn):
+        """No-op decorator."""
+        return fn
+
+except ImportError as err:
+    def netifaces_is_available(_):
+        """Decorator which raises an ImportError because netifaces is not available."""
+        def fail(*args, **kwargs):
+            """Raise ImportError since netifaces is not available."""
+            raise ImportError("%s; netifaces is not available")
+
+        return fail
+
+try:
+    import netaddr
+    def netaddr_is_available(fn):
+        """No-op decorator."""
+        return fn
+
+except ImportError as err:
+    def netaddr_is_available(_):
+        """Decorator which raises an ImportError because netaddr is not available."""
+        def fail(*args, **kwargs):
+            """Raise ImportError since netaddr is not available."""
+            raise ImportError("%s; netaddr is not available")
+
+        return fail
+
 
 NetworkInterface = namedtuple('NetworkInterface', 'hostname,addr,device,mask_bits')
 _log = fancylogger.getLogger(fname=False)
 
 
+@netaddr_is_available
 def netmask2maskbits(netmask):
     """Find the number of bits in a netmask."""
     mask_as_int = netaddr.IPAddress(netmask).value
     return bin(mask_as_int).count('1')
 
 
+@netifaces_is_available
 def get_networks():
     """
     Returns list of NetworkInterface tuples by interface.
@@ -70,6 +100,7 @@ def get_networks():
     return networks
 
 
+@netaddr_is_available
 def address_in_network(ip, net):
     """
     Determine if an ip is in a network.

--- a/hod/options.py
+++ b/hod/options.py
@@ -69,3 +69,17 @@ def validate_pbs_option(options):
         return False
 
     return True
+
+def validate_genconfig_option(options):
+    """pbs options require a config and a workdir"""
+    if not options.hodconf and not options.dist:
+        _log.error('Either --hodconf or --dist must be set')
+        return False
+    if options.hodconf and options.dist:
+        _log.error('Only one of --hodconf or --dist can be set')
+        return False
+    if not options.workdir:
+        _log.error('No workdir ("--workdir") provided')
+        return False
+
+    return True

--- a/hod/options.py
+++ b/hod/options.py
@@ -36,6 +36,7 @@ GENERAL_HOD_OPTIONS = {
              "This cannot be set if --hodconf is set", 'string', 'store', None),
     'hodconf': ("Top level configuration file. This can be a comma separated list of config files with "
                 "the later files taking precendence.", 'string', 'store', None),
+    'hod-module': ("Module to load for hanythingondemand in submitted job", 'string', 'store', None),
     'label': ("Cluster label", 'string', 'store', None),
     'workdir': ("Working directory", 'string', 'store', None),
 }
@@ -54,13 +55,13 @@ _log = fancylogger.getLogger('create', fname=False)
 
 def validate_pbs_option(options):
     """pbs options require a config and a workdir"""
-    if not options.options.hodconf and not options.options.dist:
+    if not options.hodconf and not options.dist:
         _log.error('Either --hodconf or --dist must be set')
         return False
-    if options.options.hodconf and options.options.dist:
+    if options.hodconf and options.dist:
         _log.error('Only one of --hodconf or --dist can be set')
         return False
-    if not options.options.workdir:
+    if not options.workdir:
         _log.error('No workdir ("--workdir") provided')
         return False
     return True

--- a/hod/options.py
+++ b/hod/options.py
@@ -64,4 +64,8 @@ def validate_pbs_option(options):
     if not options.workdir:
         _log.error('No workdir ("--workdir") provided')
         return False
+    if not options.hod_module:
+        _log.error('No hod-module ("--hod-module") provided')
+        return False
+
     return True

--- a/hod/options.py
+++ b/hod/options.py
@@ -52,8 +52,7 @@ RESOURCE_MANAGER_OPTIONS = {
 
 _log = fancylogger.getLogger('create', fname=False)
 
-
-def validate_pbs_option(options):
+def validate_required_option(options):
     """pbs options require a config and a workdir"""
     if not options.hodconf and not options.dist:
         _log.error('Either --hodconf or --dist must be set')
@@ -63,23 +62,16 @@ def validate_pbs_option(options):
         return False
     if not options.workdir:
         _log.error('No workdir ("--workdir") provided')
-        return False
-    if not options.hod_module:
-        _log.error('No hod-module ("--hod-module") provided')
         return False
 
     return True
 
-def validate_genconfig_option(options):
+def validate_pbs_option(options):
     """pbs options require a config and a workdir"""
-    if not options.hodconf and not options.dist:
-        _log.error('Either --hodconf or --dist must be set')
+    if not validate_required_option(options):
         return False
-    if options.hodconf and options.dist:
-        _log.error('Only one of --hodconf or --dist can be set')
-        return False
-    if not options.workdir:
-        _log.error('No workdir ("--workdir") provided')
+    if not options.hod_module:
+        _log.error('No hod-module ("--hod-module") provided')
         return False
 
     return True

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -119,11 +119,12 @@ class PbsHodJob(MympirunHod):
     def __init__(self, options):
         super(PbsHodJob, self).__init__(options)
 
-        if options.hod_module:
+        if options.options.hod_module:
             self.modules = [options.options.hod_module]
         else:
             sys.stderr.write("HOD module to load in job is not specified (--hod-module).\n")
             sys.exit(1)
+
 
         config_filenames = resolve_config_paths(options.options.hodconf, options.options.dist)
         self.log.debug('Manifest config paths resolved to: %s', config_filenames)

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -118,28 +118,8 @@ class PbsHodJob(MympirunHod):
     """
     def __init__(self, options):
         super(PbsHodJob, self).__init__(options)
-        self.modules = []
 
-        modname = hod.NAME
-        # TODO this is undefined, module should be provided via E, eg EBMODULENAME
-        ebmodname_envvar = 'EBMODNAME%s' % modname.upper()
-
-        ebmodname = os.environ.get(ebmodname_envvar, None)
-        if ebmodname is None:
-            # TODO: is this environment modules specific?
-            env_list = 'LOADEDMODULES'
-            self.log.debug('Missing environment variable %s, going to guess it via %s and modname %s.',
-                    ebmodname_envvar, env_list, modname)
-            candidates = [x for x in os.environ.get(env_list, '').split(':') if x.startswith(modname)]
-            if candidates:
-                ebmodname = candidates[-1]
-                self.log.debug("Using guessed modulename %s", ebmodname)
-            else:
-                self.log.raiseException('Failed to guess modulename and no EB environment variable %s set.' %
-                        ebmodname_envvar)
-
-        # FIXME
-        self.modules.append(ebmodname)
+        self.modules = [options.options.hod_module]
 
         config_filenames = resolve_config_paths(options.options.hodconf, options.options.dist)
         self.log.debug('Manifest config paths resolved to: %s', config_filenames)

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -119,7 +119,11 @@ class PbsHodJob(MympirunHod):
     def __init__(self, options):
         super(PbsHodJob, self).__init__(options)
 
-        self.modules = [options.options.hod_module]
+        if options.hod_module:
+            self.modules = [options.options.hod_module]
+        else:
+            sys.stderr.write("HOD module to load in job is not specified (--hod-module).\n")
+            sys.exit(1)
 
         config_filenames = resolve_config_paths(options.options.hodconf, options.options.dist)
         self.log.debug('Manifest config paths resolved to: %s', config_filenames)

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -119,12 +119,7 @@ class PbsHodJob(MympirunHod):
     def __init__(self, options):
         super(PbsHodJob, self).__init__(options)
 
-        if options.options.hod_module:
-            self.modules = [options.options.hod_module]
-        else:
-            sys.stderr.write("HOD module to load in job is not specified (--hod-module).\n")
-            sys.exit(1)
-
+        self.modules = [options.options.hod_module]
 
         config_filenames = resolve_config_paths(options.options.hodconf, options.options.dist)
         self.log.debug('Manifest config paths resolved to: %s', config_filenames)

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -85,7 +85,7 @@ class BatchSubCommand(SubCommand):
     def run(self, args):
         """Run 'batch' subcommand."""
         optparser = BatchOptions(go_args=args, envvar_prefix=self.envvar_prefix, usage=self.usage_txt)
-        if not validate_pbs_option(optparser):
+        if not validate_pbs_option(optparser.options):
             sys.stderr.write('Missing config options. Exiting.\n')
             return 1
 

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -79,8 +79,12 @@ class CreateSubCommand(SubCommand):
     def run(self, args):
         """Run 'create' subcommand."""
         optparser = CreateOptions(go_args=args, envvar_prefix=self.envvar_prefix, usage=self.usage_txt)
-        if not validate_pbs_option(optparser):
+        if not validate_pbs_option(optparser.options):
             sys.stderr.write('Missing config options. Exiting.\n')
+            return 1
+
+        if optparser.options.hod_module is None:
+            sys.stderr.write("HOD module to load in job is not specified (--hod-module).\n")
             return 1
 
         try:

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -83,10 +83,6 @@ class CreateSubCommand(SubCommand):
             sys.stderr.write('Missing config options. Exiting.\n')
             return 1
 
-        if optparser.options.hod_module is None:
-            sys.stderr.write("HOD module to load in job is not specified (--hod-module).\n")
-            return 1
-
         try:
             # FIXME: check whether label is already in use
             j = PbsHodJob(optparser)

--- a/hod/subcommands/genconfig.py
+++ b/hod/subcommands/genconfig.py
@@ -38,7 +38,7 @@ from vsc.utils.generaloption import GeneralOption
 from hod import VERSION as HOD_VERSION
 from hod.hodproc import ConfiguredMaster
 from hod.mpiservice import setup_tasks
-from hod.options import GENERAL_HOD_OPTIONS, validate_pbs_option
+from hod.options import GENERAL_HOD_OPTIONS, validate_genconfig_option
 from hod.subcommands.subcommand import SubCommand
 
 
@@ -68,7 +68,7 @@ class GenConfigSubCommand(SubCommand):
     def run(self, args):
         """Run 'genconfig' subcommand."""
         optparser = GenConfigOptions(go_args=args, usage=self.usage_txt)
-        if not validate_pbs_option(optparser.options):
+        if not validate_genconfig_option(optparser.options):
             sys.stderr.write('Missing config options. Exiting.\n')
             return 1
 

--- a/hod/subcommands/genconfig.py
+++ b/hod/subcommands/genconfig.py
@@ -67,12 +67,12 @@ class GenConfigSubCommand(SubCommand):
 
     def run(self, args):
         """Run 'genconfig' subcommand."""
-        options = GenConfigOptions(go_args=args, usage=self.usage_txt)
-        if not validate_pbs_option(options):
+        optparser = GenConfigOptions(go_args=args, usage=self.usage_txt)
+        if not validate_pbs_option(optparser.options):
             sys.stderr.write('Missing config options. Exiting.\n')
             return 1
 
-        svc = ConfiguredMaster(options)
+        svc = ConfiguredMaster(optparser.options)
         try:
             setup_tasks(svc)
             return 0

--- a/hod/subcommands/genconfig.py
+++ b/hod/subcommands/genconfig.py
@@ -38,7 +38,7 @@ from vsc.utils.generaloption import GeneralOption
 from hod import VERSION as HOD_VERSION
 from hod.hodproc import ConfiguredMaster
 from hod.mpiservice import setup_tasks
-from hod.options import GENERAL_HOD_OPTIONS, validate_genconfig_option
+from hod.options import GENERAL_HOD_OPTIONS, validate_required_option
 from hod.subcommands.subcommand import SubCommand
 
 
@@ -68,7 +68,7 @@ class GenConfigSubCommand(SubCommand):
     def run(self, args):
         """Run 'genconfig' subcommand."""
         optparser = GenConfigOptions(go_args=args, usage=self.usage_txt)
-        if not validate_genconfig_option(optparser.options):
+        if not validate_required_option(optparser.options):
             sys.stderr.write('Missing config options. Exiting.\n')
             return 1
 

--- a/test/unit/subcommands/test_subcommands_batch.py
+++ b/test/unit/subcommands/test_subcommands_batch.py
@@ -45,29 +45,29 @@ class TestBatchSubCommand(unittest.TestCase):
     def test_run_with_hodconf_and_no_script(self):
         with patch('hod.subcommands.batch.PbsHodJob'):
             app = BatchSubCommand()
-            self.assertEqual(1, app.run(['--hodconf=hod.conf', '--workdir=workdir']))
+            self.assertEqual(1, app.run(['--hodconf=hod.conf', '--workdir=workdir', '--hod-module=hanythingondemand']))
 
     def test_run_fails_with_dist_and_no_script(self):
         with patch('hod.subcommands.batch.PbsHodJob'):
             app = BatchSubCommand()
-            self.assertEqual(1, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir']))
+            self.assertEqual(1, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--hod-module=hanythingondemand']))
 
     def test_run_with_hodconf(self):
         with patch('hod.subcommands.batch.PbsHodJob'):
             app = BatchSubCommand()
-            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--script=some-script.sh']))
+            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--hod-module=hanythingondemand', '--script=some-script.sh']))
 
 
     def test_run_with_dist(self):
         with patch('hod.subcommands.batch.PbsHodJob'):
             app = BatchSubCommand()
-            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--script=some-script.sh']))
+            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--hod-module=hanythingondemand', '--script=some-script.sh']))
 
 
     def test_run_fails_with_config_and_dist_arg(self):
         with patch('hod.subcommands.batch.PbsHodJob'):
             app = BatchSubCommand()
-            self.assertEqual(1, app.run(['--hodconf=hod.conf', '--dist=Hadoop-2.3.0', '--workdir=workdir']))
+            self.assertEqual(1, app.run(['--hodconf=hod.conf', '--dist=Hadoop-2.3.0', '--hod-module=hanythingondemand', '--workdir=workdir']))
 
     def test_usage(self):
         app = BatchSubCommand()

--- a/test/unit/subcommands/test_subcommands_create.py
+++ b/test/unit/subcommands/test_subcommands_create.py
@@ -45,17 +45,17 @@ class TestCreateSubCommand(unittest.TestCase):
     def test_run_with_args(self):
         with patch('hod.subcommands.create.PbsHodJob'):
             app = CreateSubCommand()
-            app.run(['--hodconf=hod.conf', '--workdir=workdir'])
+            app.run(['--hodconf=hod.conf', '--workdir=workdir', '--hod-module=hanythingondemand'])
 
     def test_run_with_dist_arg(self):
         with patch('hod.subcommands.create.PbsHodJob'):
             app = CreateSubCommand()
-            app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir'])
+            app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--hod-module=hanythingondemand'])
 
     def test_run_fails_with_config_and_dist_arg(self):
         with patch('hod.subcommands.create.PbsHodJob'):
             app = CreateSubCommand()
-            self.assertEqual(app.run(['--hodconf=hod.conf', '--dist=Hadoop-2.3.0', '--workdir=workdir']), 1)
+            self.assertEqual(app.run(['--hodconf=hod.conf', '--dist=Hadoop-2.3.0', '--workdir=workdir', '--hod-module=hanythingondemand']), 1)
 
     def test_usage(self):
         app = CreateSubCommand()

--- a/test/unit/test_option.py
+++ b/test/unit/test_option.py
@@ -1,0 +1,60 @@
+###
+# Copyright 2009-2014 Ghent University
+#
+# This file is part of hanythingondemand
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/hanythingondemand
+#
+# hanythingondemand is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# hanythingondemand is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hanythingondemand. If not, see <http://www.gnu.org/licenses/>.
+'''
+@author Ewan Higgs (Universiteit Gent)
+'''
+
+import unittest
+from mock import MagicMock
+
+import hod.options as ho
+
+class TestOption(unittest.TestCase):
+    def test_validate_pbs_option(self):
+        options = MagicMock(workdir='/', dist='Hadoop', hod_module='hod', hodconf=None)
+        self.assertTrue(ho.validate_pbs_option(options))
+
+    def test_validate_genconfig_option_fails_with_config_and_dist(self):
+        options = MagicMock(workdir='/', dist='Hadoop', hod_module='hod', hodconf='hod.conf')
+        self.assertFalse(ho.validate_pbs_option(options))
+
+    def test_validate_genconfig_option_fails_missing_dist_or_config(self):
+        options = MagicMock(workdir='/', hod_module='')
+        self.assertFalse(ho.validate_pbs_option(options))
+
+    def test_validate_genconfig_option_fails_missing_workdir(self):
+        options = MagicMock(dist='Hadoop', hod_module='hod')
+        self.assertFalse(ho.validate_pbs_option(options))
+
+    def test_validate_genconfig_option_fails_missing_hod_module(self):
+        options = MagicMock(workdir='/', dist='Hadoop')
+        self.assertFalse(ho.validate_pbs_option(options))
+
+    def test_validate_genconfig_option(self):
+        options = MagicMock(workdir='/', dist='Hadoop', hod_module='hod', hodconf=None)
+        self.assertTrue(ho.validate_genconfig_option(options))
+
+    def test_validate_fails_missing_dist_or_config(self):
+        options = MagicMock(workdir='/')
+        self.assertFalse(ho.validate_genconfig_option(options))

--- a/test/unit/test_option.py
+++ b/test/unit/test_option.py
@@ -35,26 +35,26 @@ class TestOption(unittest.TestCase):
         options = MagicMock(workdir='/', dist='Hadoop', hod_module='hod', hodconf=None)
         self.assertTrue(ho.validate_pbs_option(options))
 
-    def test_validate_genconfig_option_fails_with_config_and_dist(self):
+    def test_validate_required_option_fails_with_config_and_dist(self):
         options = MagicMock(workdir='/', dist='Hadoop', hod_module='hod', hodconf='hod.conf')
         self.assertFalse(ho.validate_pbs_option(options))
 
-    def test_validate_genconfig_option_fails_missing_dist_or_config(self):
+    def test_validate_required_option_fails_missing_dist_or_config(self):
         options = MagicMock(workdir='/', hod_module='')
         self.assertFalse(ho.validate_pbs_option(options))
 
-    def test_validate_genconfig_option_fails_missing_workdir(self):
+    def test_validate_required_option_fails_missing_workdir(self):
         options = MagicMock(dist='Hadoop', hod_module='hod')
         self.assertFalse(ho.validate_pbs_option(options))
 
-    def test_validate_genconfig_option_fails_missing_hod_module(self):
+    def test_validate_required_option_fails_missing_hod_module(self):
         options = MagicMock(workdir='/', dist='Hadoop')
         self.assertFalse(ho.validate_pbs_option(options))
 
-    def test_validate_genconfig_option(self):
+    def test_validate_required_option(self):
         options = MagicMock(workdir='/', dist='Hadoop', hod_module='hod', hodconf=None)
-        self.assertTrue(ho.validate_genconfig_option(options))
+        self.assertTrue(ho.validate_required_option(options))
 
     def test_validate_fails_missing_dist_or_config(self):
         options = MagicMock(workdir='/')
-        self.assertFalse(ho.validate_genconfig_option(options))
+        self.assertFalse(ho.validate_required_option(options))


### PR DESCRIPTION
@ehiggs: This enables me to submit to golett from the login nodes, using the system Python, as follows:

```
hod create --workdir=$VSC_SCRATCH/hod --dist=IPython-notebook-3.2.1 --hod-module=hanythingondemand/3.0.0dev-intel-2015a-Python-2.7.10
```

Seems to be working (I can connect to the IPython web UI for a cluster that was submitted like this).
