### PR TITLE
Document ipython logging; use HOD_LOCALWORKDIR in docs. doc hod clean.

### DIFF
--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -96,7 +96,7 @@ Create a hanythingondemand cluster, with the specified label (optional) and clus
 
 The configuration file can be a filepath, or one of the included cluster configuration files (see :ref:`cmdline_dists`).
 
-Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<no-job>`` until ``hod clean`` 
+Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<job-not-found>`` until ``hod clean`` 
 is run (see :ref:`cmdline_clean`).
 
 .. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
@@ -193,7 +193,7 @@ Next to ``--script`` (which is mandatory with ``batch``), all configuration opti
 also supported for ``batch``, see :ref:`cmdline_create_options`.
 When used with ``batch``, these options can also be specified via ``$HOD_BATCH_*``.
 
-Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<no-job>`` until ``hod clean`` 
+Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<job-not-found>`` until ``hod clean`` 
 is run (see :ref:`cmdline_clean`).
 
 .. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
@@ -208,7 +208,7 @@ is run (see :ref:`cmdline_clean`).
 
 Print a list of existing clusters, and their state ('``queued``' or '``running``').
 
-Jobs that have completed running will remain in the list with ``<no-job>`` until
+Jobs that have completed running will remain in the list with ``<job-not-found>`` until
 ``hod clean`` is run.
 
 See :ref:`cmdline_clean`.
@@ -259,5 +259,5 @@ that was created for this cluster (``$HOME/.config/hod.d/<label>/env``).
 ``hod clean``
 ~~~~~~~~~~~~~
 
-Remove cluster info directory for clusters that are no longer available, i.e.  those marked with ``<no-job>`` in the 
+Remove cluster info directory for clusters that are no longer available, i.e.  those marked with ``<job-not-found>`` in the 
 output of ``hod list``.

--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -34,6 +34,7 @@ Running ``hod`` without arguments is equivalent to ``hod --help``, and results i
         help-template   Print the values of the configuration templates based on the current machine.
         genconfig       Write hod configs to a directory for diagnostic purposes
         connect         Connect to a hod cluster.
+        clean           Remove stale cluster info.
 
 .. _cmdline_hod_options:
 
@@ -201,6 +202,11 @@ When used with ``batch``, these options can also be specified via ``$HOD_BATCH_*
 
 Print a list of existing clusters, and their state ('``queued``' or '``running``').
 
+Jobs that have completed running will remain in the list with ``<no-job>`` until
+``hod clean`` is run.
+
+See :ref:`cmdline_clean`.
+
 
 .. _cmdline_dists:
 
@@ -241,3 +247,10 @@ Connect to an existing hanythingondemand cluster, and set up the environment to 
 
 This basically corresponds to logging in to the cluster head node using SSH and sourcing the cluster information script
 that was created for this cluster (``$HOME/.config/hod.d/<label>/env``).
+
+.. _cmdline_clean:
+
+``hod clean``
+~~~~~~~~~~~~~
+
+Remove old cluster labels that will appear in ``hod list``.

--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -96,6 +96,9 @@ Create a hanythingondemand cluster, with the specified label (optional) and clus
 
 The configuration file can be a filepath, or one of the included cluster configuration files (see :ref:`cmdline_dists`).
 
+Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<no-job>`` until ``hod clean`` 
+is run.
+
 .. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
 
 
@@ -190,6 +193,9 @@ Next to ``--script`` (which is mandatory with ``batch``), all configuration opti
 also supported for ``batch``, see :ref:`cmdline_create_options`.
 When used with ``batch``, these options can also be specified via ``$HOD_BATCH_*``.
 
+Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<no-job>`` until ``hod clean`` 
+is run.
+
 .. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
 
 
@@ -253,4 +259,5 @@ that was created for this cluster (``$HOME/.config/hod.d/<label>/env``).
 ``hod clean``
 ~~~~~~~~~~~~~
 
-Remove old cluster labels that will appear in ``hod list``.
+Remove cluster info directory for clusters that are no longer available, i.e.  those marked with ``<no-job>`` in the 
+output of ``hod list``.

--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -97,7 +97,7 @@ Create a hanythingondemand cluster, with the specified label (optional) and clus
 The configuration file can be a filepath, or one of the included cluster configuration files (see :ref:`cmdline_dists`).
 
 Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<no-job>`` until ``hod clean`` 
-is run.
+is run (see :ref:`cmdline_clean`).
 
 .. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
 
@@ -194,7 +194,7 @@ also supported for ``batch``, see :ref:`cmdline_create_options`.
 When used with ``batch``, these options can also be specified via ``$HOD_BATCH_*``.
 
 Jobs that have completed will remain in the output of ``hod list`` with a job id of ``<no-job>`` until ``hod clean`` 
-is run.
+is run (see :ref:`cmdline_clean`).
 
 .. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
 

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -90,8 +90,8 @@ Preview configuration
 To preview the output configuration files that your ``hod.conf`` file would
 produce, one can use the ``genconfig`` command::
 
-    hod-genconfig --config-config=/path/to/hod.conf --config-workdir=/path/to/workdir
+    hod genconfig --hodconf=/path/to/hod.conf --workdir=/path/to/workdir
 
-Here, ``--config-workdir`` is the output directory (which will be created if it
-doesn't yet exist) and ``--config-config`` is the input configuration file.
+Here, ``--workdir`` is the output directory (which will be created if it
+doesn't yet exist) and ``--hodconf`` is the input configuration file.
 

--- a/docs/Logging.rst
+++ b/docs/Logging.rst
@@ -51,7 +51,11 @@ Service logs
 Hadoop logs
 ***********
 
-By default, the log files for a Hadoop cluster will be in ``$HOD_LOCALWORKDIR/log``.
+By default, the log files for a Hadoop cluster will be in ``$HOD_LOCALWORKDIR/log``, where the 
+``HOD_LOCALWORKDIR`` is an environment variable set by ``hod connect``.
+
+Expanded, this is in the workdir of the HOD cluster as follows:
+``$workdir/${USER}.${HOSTNAME}.${PID}/log``
 
 One of the advantages of having the log files on a parallel file system is that
 one no longer needs to use special tools for log aggregation (Flume, Logstash,
@@ -70,8 +74,21 @@ Hadoop logs have two components:
 
    $HOD_LOCALWORKDIR/log/userlogs/application_1430748293929_0001/container_1430748293929_0001_01_000003/stdout
 
+.. _logging_service_logs_ipython:
+
 IPython logs
 ************
 
 IPython logs to stdout and stderr. These are sent by hanythingondemand to
 ``$HOD_LOCALWORKDIR/log/pyspark.stdout`` and ``$HOD_LOCALWORKDIR/log/pyspark.stderr``
+
+.. _logging_service_logs_hod_batch:
+
+``hod batch`` logs
+******************
+
+Logs for your script running under ``hod batch`` are found in your PBS logs:
+``HOD_<job-label>.o<job-id>``
+
+If you want to watch the progress of your job while it's running, it's advisable to write your
+script so that it pipes output to the ``tee`` command.

--- a/docs/Logging.rst
+++ b/docs/Logging.rst
@@ -5,7 +5,7 @@ Logging
 
 If your job didn't work as expected, you'll need to check the logs.
 
-It's important to realise that both *hanythingondemand* itself and the services it is running (e.g., Hadoop) produce
+It's important to realise that both *hanythingondemand* itself and the services it is running (e.g. Hadoop) produce
 logs.
 
 Which logs you should be diving into depends on the information you are looking for or the kind of problems
@@ -51,8 +51,7 @@ Service logs
 Hadoop logs
 ***********
 
-By default, the log files for a Hadoop cluster will be in ``$localworkdir/log``.
-Expanded, this is in the workdir of the HOD cluster as follows: ``$workdir/${USER}.${HOSTNAME}.${PID}/log``.
+By default, the log files for a Hadoop cluster will be in ``$HOD_LOCALWORKDIR/log``.
 
 One of the advantages of having the log files on a parallel file system is that
 one no longer needs to use special tools for log aggregation (Flume, Logstash,
@@ -61,7 +60,7 @@ structure.
 
 Hadoop logs have two components:
 
-1. *Service logs*: These are in ``$localworkdir/log``. Examples are:
+1. *Service logs*: These are in ``$HOD_LOCALWORKDIR/log``. Examples are:
    ``yarn-username-resourcemanager-node.domain.out``,
    ``yarn-username-nodemanager-node.domain.out``.
 
@@ -69,4 +68,10 @@ Hadoop logs have two components:
    Output from your program will appear in these files.  These
    are organized by application/container/stderr and stdout. For example: ::
 
-   $localworkdir/log/userlogs/application_1430748293929_0001/container_1430748293929_0001_01_000003/stdout
+   $HOD_LOCALWORKDIR/log/userlogs/application_1430748293929_0001/container_1430748293929_0001_01_000003/stdout
+
+IPython logs
+************
+
+IPython logs to stdout and stderr. These are sent by hanythingondemand to
+``$HOD_LOCALWORKDIR/log/pyspark.stdout`` and ``$HOD_LOCALWORKDIR/log/pyspark.stderr``

--- a/docs/Logging.rst
+++ b/docs/Logging.rst
@@ -52,10 +52,10 @@ Hadoop logs
 ***********
 
 By default, the log files for a Hadoop cluster will be in ``$HOD_LOCALWORKDIR/log``, where the 
-``HOD_LOCALWORKDIR`` is an environment variable set by ``hod connect``.
+``$HOD_LOCALWORKDIR`` is an environment variable set by ``hod connect``.
 
 Expanded, this is in the workdir of the HOD cluster as follows:
-``$workdir/${USER}.${HOSTNAME}.${PID}/log``
+``$workdir/$PBS_JOBID/${USER}.${HOSTNAME}.${PID}/log``
 
 One of the advantages of having the log files on a parallel file system is that
 one no longer needs to use special tools for log aggregation (Flume, Logstash,
@@ -87,8 +87,8 @@ IPython logs to stdout and stderr. These are sent by hanythingondemand to
 ``hod batch`` logs
 ******************
 
-Logs for your script running under ``hod batch`` are found in your `PBS_O_WORKDIR` in:
-`<script-name>.o<$PBS_JOBID>` and `<script-name>.e<$PBS_JOBID>.
+Logs for your script running under ``hod batch`` are found in your ``$PBS_O_WORKDIR`` in:
+``<script-name>.o<$PBS_JOBID>`` and ``<script-name>.e<$PBS_JOBID>``.
 
 If you want to watch the progress of your job while it's running, it's advisable to write your
 script so that it pipes output to the ``tee`` command.

--- a/docs/Logging.rst
+++ b/docs/Logging.rst
@@ -87,8 +87,8 @@ IPython logs to stdout and stderr. These are sent by hanythingondemand to
 ``hod batch`` logs
 ******************
 
-Logs for your script running under ``hod batch`` are found in your PBS logs:
-``HOD_<job-label>.o<job-id>``
+Logs for your script running under ``hod batch`` are found in your `PBS_O_WORKDIR` in:
+`<script-name>.o<$PBS_JOBID>` and `<script-name>.e<$PBS_JOBID>.
 
 If you want to watch the progress of your job while it's running, it's advisable to write your
 script so that it pipes output to the ``tee`` command.


### PR DESCRIPTION
Implements #79, #76, and adds ipython logging documentation.