### PR TITLE
Batch fixes

### DIFF
--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -42,8 +42,11 @@ import time
 from vsc.utils import fancylogger
 
 
-COMMAND_TIMEOUT = 120  # timeout
-NO_TIMEOUT = -1
+COMMAND_TIMEOUT = 120  # timeout in seconds
+NO_TIMEOUT = None # No timeout
+
+TIMEOUT_POLL_TIME = 1
+NO_TIMEOUT_POLL_TIME = 10
 
 
 class Command(object):
@@ -125,7 +128,7 @@ class Command(object):
             if os.path.exists("/proc/%s" % (p.pid)):
                 if self.timeout == NO_TIMEOUT:
                     self.log.debug("There is no timeout for cmd %s and it is still running" % self.command)
-                    time.sleep(10)
+                    time.sleep(NO_TIMEOUT_POLL_TIME)
                     continue
                 else:
                     now = datetime.datetime.now()
@@ -137,7 +140,7 @@ class Command(object):
                             timedout = True
                         else:
                             os.kill(p.pid, signal.SIGKILL)
-            time.sleep(1)
+            time.sleep(TIMEOUT_POLL_TIME)
 
         if self.fake_pty:
             # # no stdout/stderr

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -36,6 +36,7 @@ from pkg_resources import Requirement, resource_filename, resource_listdir
 
 import hod
 from hod.node.node import Node
+from hod.commands.command import COMMAND_TIMEOUT
 from hod.config.template import mklocalworkdir
 
 
@@ -325,16 +326,17 @@ class ConfigOpts(object):
 
     def to_params(self, workdir, modules, master_template_args):
         """Create a ConfigOptsParams object from the ConfigOpts instance"""
-        return ConfigOptsParams(self.name, self._runs_on, self._pre_start_script, self._start_script, 
-                                self._stop_script, self._env, workdir, modules, master_template_args)
+        return ConfigOptsParams(self.name, self._runs_on, self._pre_start_script, self._start_script,
+                                self._stop_script, self._env, workdir, modules, master_template_args, self.timeout)
 
     @staticmethod
     def from_params(params, template_resolver):
         """Create a ConfigOpts instance from a ConfigOptsParams instance"""
         return ConfigOpts(params.name, params.runs_on, params.pre_start_script, params.start_script,
-                          params.stop_script, params.env, template_resolver)
+                          params.stop_script, params.env, template_resolver, params.timeout)
 
-    def __init__(self, name, runs_on, pre_start_script, start_script, stop_script, env, template_resolver):
+    def __init__(self, name, runs_on, pre_start_script, start_script, stop_script, env, template_resolver, 
+                    timeout=COMMAND_TIMEOUT):
         self.name = name
         self._runs_on = runs_on
         self._tr = template_resolver
@@ -342,6 +344,7 @@ class ConfigOpts(object):
         self._start_script = start_script
         self._stop_script = stop_script
         self._env = env
+        self.timeout = timeout
 
     @property
     def pre_start_script(self):
@@ -411,7 +414,8 @@ ConfigOptsParams = namedtuple('ConfigOptsParams', [
     'env',
     'workdir',
     'modules',
-    'master_template_kwargs'
+    'master_template_kwargs',
+    'timeout',
 ])
 
 def autogen_fn(name):

--- a/hod/hodproc.py
+++ b/hod/hodproc.py
@@ -103,11 +103,12 @@ def _script_output_paths(script_name, label=None):
     """
     script_basename = os.path.basename(script_name)
     if label is None:
-        script_stdout = mkpath('$PBS_O_WORKDIR', 'hod-%s.o${PBS_JOBID}' % script_basename)
-        script_stderr = mkpath('$PBS_O_WORKDIR', 'hod-%s.e${PBS_JOBID}' % script_basename)
+        output_label = 'hod-%s' % script_basename
     else:
-        script_stdout = mkpath('$PBS_O_WORKDIR', 'hod-%s-%s.o${PBS_JOBID}' % (label, script_basename))
-        script_stderr = mkpath('$PBS_O_WORKDIR', 'hod-%s-%s.e${PBS_JOBID}' % (label, script_basename))
+        output_label = 'hod-%s-%s' % (label, script_basename)
+
+    script_stdout = mkpath('$PBS_O_WORKDIR', '%s.o${PBS_JOBID}' % output_label)
+    script_stderr = mkpath('$PBS_O_WORKDIR', '%s.e${PBS_JOBID}' % output_label)
     return (script_stdout, script_stderr)
 
 

--- a/hod/subcommands/helptemplate.py
+++ b/hod/subcommands/helptemplate.py
@@ -35,6 +35,7 @@ from hod import VERSION as HOD_VERSION
 from hod.subcommands.subcommand import SubCommand
 from hod.mpiservice import master_template_opts
 from hod.config.config import ConfigOptsParams
+from hod.commands.command import COMMAND_TIMEOUT
 
 
 class HelpTemplateOptions(GeneralOption):
@@ -45,7 +46,8 @@ class HelpTemplateOptions(GeneralOption):
 def mk_registry():
     """Make a TemplateRegistry and register basic items"""
     config_opts = ConfigOptsParams('svc-name', 'MASTER', 'ExecPreStart', 'ExecStart', 'ExecStop',
-                                   dict(), workdir='WORKDIR', modules=['MODULES'], master_template_kwargs=[])
+                                   dict(), workdir='WORKDIR', modules=['MODULES'], master_template_kwargs=[],
+                                   timeout=COMMAND_TIMEOUT)
     reg = hct.TemplateRegistry()
     hct.register_templates(reg, config_opts)
     master_template_kwargs = master_template_opts(reg.fields.values())

--- a/hod/work/config_service.py
+++ b/hod/work/config_service.py
@@ -75,7 +75,7 @@ class ConfiguredService(Work):
                 self._config.name, rank, self._config.start_script)
         self.log.info("Env for %s service on rank %s: %s",
                 self._config.name, rank, env2str(env))
-        command = Command(self._config.start_script, env=env)
+        command = Command(self._config.start_script, env=env, timeout=self._config.timeout)
         output = command.run()
         self.log.info('Ran %s service on rank %s start script. Output: "%s"',
                 self._config.name, rank, output)

--- a/test/unit/test_hodproc.py
+++ b/test/unit/test_hodproc.py
@@ -102,3 +102,13 @@ class TestHodProcConfiguredMaster(unittest.TestCase):
         self.assertTrue(cm.tasks is None) # slaves don't collect tasks.
         self.assertTrue(autogen_config.called)
         self.assertEqual(autogen_config.call_count, 1)
+
+    def test_script_output_paths_nolabel(self):
+        out, err = hh._script_output_paths('script_name')
+        self.assertEqual(out, '$PBS_O_WORKDIR/hod-script_name.o${PBS_JOBID}')
+        self.assertEqual(err, '$PBS_O_WORKDIR/hod-script_name.e${PBS_JOBID}')
+
+    def test_script_output_paths_label(self):
+        out, err = hh._script_output_paths('script_name', 'label')
+        self.assertEqual(out, '$PBS_O_WORKDIR/hod-label-script_name.o${PBS_JOBID}')
+        self.assertEqual(err, '$PBS_O_WORKDIR/hod-label-script_name.e${PBS_JOBID}')

--- a/test/unit/test_hodproc.py
+++ b/test/unit/test_hodproc.py
@@ -108,6 +108,12 @@ class TestHodProcConfiguredMaster(unittest.TestCase):
         self.assertEqual(out, '$PBS_O_WORKDIR/hod-script_name.o${PBS_JOBID}')
         self.assertEqual(err, '$PBS_O_WORKDIR/hod-script_name.e${PBS_JOBID}')
 
+    def test_script_output_paths_nolabel_abspath(self):
+        out, err = hh._script_output_paths('/path/to/script/script_name')
+        self.assertEqual(out, '$PBS_O_WORKDIR/hod-script_name.o${PBS_JOBID}')
+        self.assertEqual(err, '$PBS_O_WORKDIR/hod-script_name.e${PBS_JOBID}')
+
+
     def test_script_output_paths_label(self):
         out, err = hh._script_output_paths('script_name', 'label')
         self.assertEqual(out, '$PBS_O_WORKDIR/hod-label-script_name.o${PBS_JOBID}')


### PR DESCRIPTION
Send batch job output to files.

Give batch jobs unlimited timeouts. Using a simple wordcount job didn't catch the fact that batch jobs had a 120 second timeout as the rest of the services (which are sent to the bg).