### PR TITLE
Use PBS_JOBID in the localworkdir to group localworkdirs together.

### DIFF
--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -37,7 +37,7 @@ from pkg_resources import Requirement, resource_filename, resource_listdir
 import hod
 from hod.node.node import Node
 from hod.commands.command import COMMAND_TIMEOUT
-from hod.config.template import mklocalworkdir
+import hod.config.template as hct
 
 
 from vsc.utils import fancylogger
@@ -187,7 +187,7 @@ class PreServiceConfigOpts(object):
 
     @property
     def localworkdir(self):
-        return mklocalworkdir(self.workdir)
+        return hct.mklocalworkdir(self.workdir)
 
     @property
     def configdir(self):
@@ -364,7 +364,7 @@ class ConfigOpts(object):
 
     @property
     def localworkdir(self):
-        return mklocalworkdir(self._tr.workdir)
+        return hct.mklocalworkdir(self._tr.workdir)
 
     @property
     def configdir(self):

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -363,8 +363,8 @@ class ConfigOpts(object):
         return self._tr.workdir
 
     @property
-    def localworkdir(self, label=None):
-        return mklocalworkdir(self._tr.workdir, label=None)
+    def localworkdir(self):
+        return mklocalworkdir(self._tr.workdir)
 
     @property
     def configdir(self):

--- a/hod/config/template.py
+++ b/hod/config/template.py
@@ -105,18 +105,17 @@ def register_templates(template_registry, config_opts):
     for ct in templates:
         template_registry.register(ct)
 
-def mklocalworkdir(workdir, label=None):
+def mklocalworkdir(workdir):
     '''
     Construct the pathname for a workdir with a path local to this
     host/job/user.
     '''
     user = _current_user()
     pid = os.getpid()
+    jobid = os.getenv('PBS_JOBID', '')
     hostname = socket.getfqdn()
     dir_name = '.'.join([user, hostname, str(pid)])
-    if label:
-        dir_name = '%s.%s' % (label, dir_name)
-    return mkpath(workdir, 'hod', dir_name)
+    return mkpath(workdir, 'hod', jobid, dir_name)
 
 def _current_user():
     '''

--- a/hod/config/template.py
+++ b/hod/config/template.py
@@ -114,7 +114,7 @@ def mklocalworkdir(workdir):
     pid = os.getpid()
     jobid = os.getenv('PBS_JOBID')
     if jobid is None:
-        raise RuntimeError('PBS_JOBID must be defined to create a localworkdir.')
+        raise RuntimeError('$PBS_JOBID must be defined to create a localworkdir.')
     hostname = socket.getfqdn()
     dir_name = '.'.join([user, hostname, str(pid)])
     return mkpath(workdir, 'hod', jobid, dir_name)

--- a/hod/config/template.py
+++ b/hod/config/template.py
@@ -112,7 +112,9 @@ def mklocalworkdir(workdir):
     '''
     user = _current_user()
     pid = os.getpid()
-    jobid = os.getenv('PBS_JOBID', '')
+    jobid = os.getenv('PBS_JOBID')
+    if jobid is None:
+        raise RuntimeError('PBS_JOBID must be defined to create a localworkdir.')
     hostname = socket.getfqdn()
     dir_name = '.'.join([user, hostname, str(pid)])
     return mkpath(workdir, 'hod', jobid, dir_name)

--- a/test/unit/config/test_template.py
+++ b/test/unit/config/test_template.py
@@ -71,6 +71,21 @@ class TestConfigTemplate(unittest.TestCase):
         self.assertEqual(hct.resolve_config_str('someval', **dict(configdir='someval')), 'someval')
         self.assertEqual(hct.resolve_config_str(47, **dict(configdir='someval')), 47)
 
+    def test_localworkdir_no_jobid(self):
+        with patch('hod.config.template._current_user', return_value='username'):
+            with patch('os.getpid', return_value='123'):
+                with patch('socket.getfqdn', return_value='hostname'):
+                    with patch('os.getenv', return_value=''):
+                        self.assertEqual('workdir/hod/username.hostname.123', hct.mklocalworkdir('workdir'))
+
+    def test_localworkdir_jobid(self):
+        with patch('hod.config.template._current_user', return_value='username'):
+            with patch('os.getpid', return_value='123'):
+                with patch('socket.getfqdn', return_value='hostname'):
+                    with patch('os.getenv', return_value='jobid'):
+                        self.assertEqual('workdir/hod/jobid/username.hostname.123', hct.mklocalworkdir('workdir'))
+
+
     def test_TemplateResolver(self):
         with patch('hod.config.template.os.environ', dict(BINDIR='/usr/bin')):
             tr = hct.TemplateResolver(workdir='someval', greeting='hello')

--- a/test/unit/config/test_template.py
+++ b/test/unit/config/test_template.py
@@ -75,8 +75,8 @@ class TestConfigTemplate(unittest.TestCase):
         with patch('hod.config.template._current_user', return_value='username'):
             with patch('os.getpid', return_value='123'):
                 with patch('socket.getfqdn', return_value='hostname'):
-                    with patch('os.getenv', return_value=''):
-                        self.assertEqual('workdir/hod/username.hostname.123', hct.mklocalworkdir('workdir'))
+                    with patch('os.getenv', return_value=None):
+                        self.assertRaises(RuntimeError, hct.mklocalworkdir, 'workdir')
 
     def test_localworkdir_jobid(self):
         with patch('hod.config.template._current_user', return_value='username'):

--- a/test/unit/subcommands/test_subcommands_helptemplate.py
+++ b/test/unit/subcommands/test_subcommands_helptemplate.py
@@ -29,12 +29,15 @@
 
 import unittest
 import pytest
+from mock import patch
+
 from hod.subcommands.helptemplate import HelpTemplateSubCommand
 
 class TestHelpTemplateApplication(unittest.TestCase):
     def test_run(self):
         app = HelpTemplateSubCommand()
-        app.run([])
+        with patch('hod.config.template.mklocalworkdir', return_value='localworkdir'):
+            app.run([])
 
     def test_usage(self):
         app = HelpTemplateSubCommand()

--- a/test/unit/test_hodproc.py
+++ b/test/unit/test_hodproc.py
@@ -80,8 +80,9 @@ class TestHodProcConfiguredMaster(unittest.TestCase):
             with patch('hod.config.config.PreServiceConfigOpts.autogen_configs',
                     side_effect=autogen_config):
                 with patch('hod.hodproc.resolve_config_paths', side_effect=['hod.conf']):
-                    with patch('__builtin__.open', side_effect=_mock_open):
-                        cm.distribution()
+                    with patch('hod.config.template.mklocalworkdir', return_value='localworkdir'):
+                        with patch('__builtin__.open', side_effect=_mock_open):
+                            cm.distribution()
         self.assertEqual(len(cm.tasks), 1)
         self.assertTrue(autogen_config.called)
         self.assertEqual(autogen_config.call_count, 1)
@@ -97,8 +98,9 @@ class TestHodProcConfiguredMaster(unittest.TestCase):
             with patch('hod.config.config.PreServiceConfigOpts.autogen_configs',
                     side_effect=autogen_config):
                 with patch('hod.hodproc.resolve_config_paths', side_effect=['hod.conf']):
-                    with patch('__builtin__.open', side_effect=_mock_open):
-                        cm.distribution()
+                    with patch('hod.config.template.mklocalworkdir', return_value='localworkdir'):
+                        with patch('__builtin__.open', side_effect=_mock_open):
+                            cm.distribution()
         self.assertTrue(cm.tasks is None) # slaves don't collect tasks.
         self.assertTrue(autogen_config.called)
         self.assertEqual(autogen_config.call_count, 1)

--- a/test/unit/work/test_work_config_service.py
+++ b/test/unit/work/test_work_config_service.py
@@ -87,6 +87,6 @@ class TestHodWorkConfiguredService(unittest.TestCase):
         cs = hwc.ConfiguredService(cfg)
         localworkdir = '/tmp/label.node1234.user.123'
         with patch('hod.work.config_service.os.makedirs', side_effect=lambda *args: None):
-            with patch('hod.config.config.mklocalworkdir', side_effect=lambda *args, **kwargs: localworkdir):
+            with patch('hod.config.template.mklocalworkdir', side_effect=lambda *args, **kwargs: localworkdir):
                 cs.prepare_work_cfg()
         self.assertEqual(cs.controldir, os.path.join(localworkdir, 'controldir'))


### PR DESCRIPTION
This lets us search logs more easily across nodes, and remove old cluster files
since we know they're all under the jobid dir.