### PR TITLE
add vsc-install as dep for testenv in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist=py{26,27}
 
 [testenv]
 deps =
+    git+https://github.com/hpcugent/vsc-install.git
     git+https://github.com/hpcugent/vsc-base.git
     git+https://github.com/ehiggs/pbs-python.git
     mpi4py 


### PR DESCRIPTION
Adding vsc-install as well is required because it was split off from vsc-base, see https://github.com/hpcugent/vsc-base/pull/204

@ehiggs: please review