### PR TITLE
Spark tuning

### DIFF
--- a/etc/hod/IPython-notebook-3.2.1/hod.conf
+++ b/etc/hod/IPython-notebook-3.2.1/hod.conf
@@ -11,5 +11,5 @@ config_writer=hod.config.writer.hadoop_xml
 # Point the workdir to a path on the parallel file system using the command
 # line named argument: --config-workdir=...
 #workdir=
-autogen=hadoop
+autogen=ipython_notebook
 directories=$localworkdir/dfs/name,$localworkdir/dfs/data

--- a/etc/hod/IPython-notebook-3.2.1/ipython.conf
+++ b/etc/hod/IPython-notebook-3.2.1/ipython.conf
@@ -11,3 +11,7 @@ ExecStop=
 [Environment]
 HADOOP_CONF_DIR=$localworkdir/conf
 HADOOP_LOG_DIR=$localworkdir/log
+SPARK_CONF_DIR=$localworkdir/conf
+SPARK_LOG_DIR=$localworkdir/log
+SPARK_LOG_DIR=$localworkdir/log
+SPARK_PID_DIR=$localworkdir/pid

--- a/etc/hod/IPython-notebook-3.2.1/ipython.conf
+++ b/etc/hod/IPython-notebook-3.2.1/ipython.conf
@@ -13,5 +13,4 @@ HADOOP_CONF_DIR=$localworkdir/conf
 HADOOP_LOG_DIR=$localworkdir/log
 SPARK_CONF_DIR=$localworkdir/conf
 SPARK_LOG_DIR=$localworkdir/log
-SPARK_LOG_DIR=$localworkdir/log
 SPARK_PID_DIR=$localworkdir/pid

--- a/hod/cluster.py
+++ b/hod/cluster.py
@@ -36,7 +36,7 @@ from collections import namedtuple
 from vsc.utils import fancylogger
 
 from hod.config.config import resolve_config_paths
-import hod.hodproc as hh
+import hod.config.config as hc
 
 
 _log = fancylogger.getLogger(fname=False)
@@ -46,12 +46,13 @@ CLUSTER_ENV_TEMPLATE = """
 # make sure session is properly set up (e.g., that 'module' command is defined)
 source /etc/profile
 
+module load %(modules)s
+
 # set up environment
 export HADOOP_CONF_DIR='%(hadoop_conf_dir)s'
 export HBASE_CONF_DIR='%(hadoop_conf_dir)s'
 export HOD_LOCALWORKDIR='%(hod_localworkdir)s'
 # TODO: HADOOP_LOG_DIR?
-module load %(modules)s
 
 echo "Welcome to your hanythingondemand cluster (label: %(label)s)"
 echo
@@ -214,7 +215,7 @@ def gen_cluster_info(label, options):
     """Generate cluster info as a dict, intended to use as template values for CLUSTER_ENV_TEMPLATE."""
     # list of modules that should be loaded: modules for selected service + extra modules specified via --modules
     config_path = resolve_config_paths(options.hodconf, options.dist)
-    hodconf = hh.load_hod_config(config_path, options.workdir, options.modules)
+    hodconf = hc.load_hod_config(config_path, options.workdir, options.modules)
     cluster_info = {
         'hadoop_conf_dir': hodconf.configdir,
         'hod_localworkdir': hodconf.localworkdir,

--- a/hod/config/autogen/ipython_notebook.py
+++ b/hod/config/autogen/ipython_notebook.py
@@ -35,6 +35,9 @@ def spark_defaults(_, node_info):
     '''
     Generate spark defaults so spark uses all the resources that yarn is able to
     provide.
+
+    Defaults here are based on Cloudera's recommendations here: 
+    http://blog.cloudera.com/blog/2015/03/how-to-tune-your-apache-spark-jobs-part-2/
     '''
     memory_defaults = hcah.memory_defaults(node_info)
     num_nodes = node_info['num_nodes']
@@ -44,8 +47,8 @@ def spark_defaults(_, node_info):
     cores = (node_info['cores'] / instances_per_node)
     memory = hcac.round_mb(memory_defaults.available_memory / instances_per_node)
     dflts = {
-        'spark.executor.instances': instances,
         'spark.executor.cores': cores,
+        'spark.executor.instances': instances,
         'spark.executor.memory':  str(memory) + 'M',
         'spark.local.dir': '$localworkdir'
     }
@@ -63,10 +66,10 @@ def autogen_config(workdir, node_info):
     }
     cfg2fn = {
         # Pulled in from Hadoop
+        'capacity-scheduler.xml': hcah.capacity_scheduler_xml_defaults,
         'core-site.xml': hcah.core_site_xml_defaults,
         'mapred-site.xml': hcah.mapred_site_xml_defaults,
         'yarn-site.xml': hcah.yarn_site_xml_defaults,
-        'capacity-scheduler.xml': hcah.capacity_scheduler_xml_defaults,
         # Spark/IPython notebook specific
         'spark-defaults.conf': spark_defaults,
     }

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -516,7 +516,6 @@ def load_hod_config(filenames, workdir, modules):
     '''
     m_config_filenames = parse_comma_delim_list(filenames)
     _log.info('Loading "%s" manifest config', m_config_filenames)
-    m_config = PreServiceConfigOpts.from_file_list(m_config_filenames,
-            workdir=workdir, modules=modules)
+    m_config = PreServiceConfigOpts.from_file_list(m_config_filenames, workdir=workdir, modules=modules)
     _log.debug('Loaded manifest config: %s', str(m_config))
     return m_config

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -459,6 +459,7 @@ def service_config_fn(policy_path):
         module = __import__(module_name, fromlist=[parent_pkg])
     except ImportError as err:
         _log.error('Could not import module "%s" from "%s": %s', module_name, parent_pkg, err)
+        raise
     return getattr(module, fn)
 
 

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -506,3 +506,14 @@ def resolve_config_paths(config, dist):
         raise RuntimeError('A config or a dist must be provided')
 
     return path
+
+def load_hod_config(filenames, workdir, modules):
+    '''
+    Load the manifest config (hod.conf) files.
+    '''
+    m_config_filenames = parse_comma_delim_list(filenames)
+    _log.info('Loading "%s" manifest config', m_config_filenames)
+    m_config = PreServiceConfigOpts.from_file_list(m_config_filenames,
+            workdir=workdir, modules=modules)
+    _log.debug('Loaded manifest config: %s', str(m_config))
+    return m_config

--- a/hod/config/config.py
+++ b/hod/config/config.py
@@ -455,7 +455,10 @@ def service_config_fn(policy_path):
     module_name = '.'.join(policy_path_list[:-1])
     parent_pkg = '.'.join(policy_path_list[:-2])
     fn = policy_path_list[-1]
-    module = __import__(module_name, fromlist=[parent_pkg])
+    try:
+        module = __import__(module_name, fromlist=[parent_pkg])
+    except ImportError as err:
+        _log.error('Could not import module "%s" from "%s": %s', module_name, parent_pkg, err)
     return getattr(module, fn)
 
 

--- a/hod/config/writer/_hadoop.py
+++ b/hod/config/writer/_hadoop.py
@@ -25,7 +25,7 @@
 """
 @author: Ewan Higgs (University of Ghent)
 """
-from common import XML_PREAMBLE, HADOOP_STYLESHEET, kv2xml
+from common import XML_PREAMBLE, HADOOP_STYLESHEET, kv2xml, write_whitespace_delimited_file
 
 from vsc.utils import fancylogger
 _log = fancylogger.getLogger(fname=False)
@@ -53,6 +53,8 @@ def _write_masters(outfile, options, template_resolver):
         output += '%s\n' % (value)
     return output
  
+def _write_text_file(outfile, options, template_resolver):
+    return options
 
 def hadoop_xml(outfile, options, template_resolver):
     """Given a dict of options, write the resulting .xml or .properties file.
@@ -74,6 +76,8 @@ def hadoop_xml(outfile, options, template_resolver):
         return _write_properties(outfile, options, template_resolver)
     elif outfile.endswith('masters'):
         return _write_masters(outfile, options, template_resolver)
+    elif outfile.endswith('spark-defaults.conf'):
+        return write_whitespace_delimited_file(outfile, options, template_resolver)
     else:
         _log.error('Unrecognized hadoop file type: %s', outfile)
         raise RuntimeError('Unrecognized hadoop file type: %s' % outfile)

--- a/hod/config/writer/_hadoop.py
+++ b/hod/config/writer/_hadoop.py
@@ -30,7 +30,9 @@ from common import XML_PREAMBLE, HADOOP_STYLESHEET, kv2xml, write_whitespace_del
 from vsc.utils import fancylogger
 _log = fancylogger.getLogger(fname=False)
 
+
 def _write_xml(outfile, options, template_resolver):
+    """Return string of XML file in Hadoop configuration format."""
     output = XML_PREAMBLE + HADOOP_STYLESHEET + "<configuration>\n"
 
     for k, v in sorted(options.items()):
@@ -40,21 +42,23 @@ def _write_xml(outfile, options, template_resolver):
     output += "</configuration>"
     return output
 
+
 def _write_properties(outfile, options, template_resolver):
+    """Return string of property file in format used by log4j."""
     output = ''
     for k, v in sorted(options.items()):
         output += '%s=%s\n' % (k, v)
     return output
 
+
 def _write_masters(outfile, options, template_resolver):
+    """Write the Hadoop master file out"""
     output = ''
-    for k, v in sorted(options.items()):
+    for _, v in sorted(options.items()):
         value = template_resolver(v)
         output += '%s\n' % (value)
     return output
- 
-def _write_text_file(outfile, options, template_resolver):
-    return options
+
 
 def hadoop_xml(outfile, options, template_resolver):
     """Given a dict of options, write the resulting .xml or .properties file.

--- a/hod/config/writer/common.py
+++ b/hod/config/writer/common.py
@@ -11,3 +11,21 @@ def kv2xml(name, value):
     <value>%s</value>
 </property>
 ''' % (name, value)
+
+def write_whitespace_delimited_file(_, options, template_resolver):
+    """
+    Write a whitespace delimited file. e.g.:
+
+    property1 value1
+    property2 value2
+
+    "spark-defaults.conf" is one such example:
+    https://spark.apache.org/docs/latest/configuration.html#dynamically-loading-spark-properties
+    """
+    output = ""
+
+    for k, v in sorted(options.items()):
+        name = template_resolver(k)
+        value = template_resolver(v)
+        output += '%s %s\n' % (name, value)
+    return output

--- a/hod/config/writer/common.py
+++ b/hod/config/writer/common.py
@@ -24,8 +24,8 @@ def write_whitespace_delimited_file(_, options, template_resolver):
     """
     output = ""
 
-    for k, v in sorted(options.items()):
-        name = template_resolver(k)
-        value = template_resolver(v)
+    for key, val in sorted(options.items()):
+        name = template_resolver(key)
+        value = template_resolver(val)
         output += '%s %s\n' % (name, value)
     return output

--- a/hod/node/node.py
+++ b/hod/node/node.py
@@ -226,9 +226,9 @@ class Node(object):
         self.usablecores = None
         self.totalcores = None
 
-        self.topology = [0] # default topology plain set
-
         self.memory = {}
+        self.num_nodes = -1
+
 
     def __str__(self):
         return "FQDN %s PID %s" % (self.fqdn, self.pid)
@@ -245,6 +245,8 @@ class Node(object):
 
         self.memory = get_memory()
 
+        self.num_nodes = int(os.getenv('PBS_NUM_NODES', 1))
+
         descr = {
             'fqdn': self.fqdn,
             'network': self.network,
@@ -252,7 +254,7 @@ class Node(object):
             'cores': self.cores,
             'usablecores': self.usablecores,
             'totalcores': self.totalcores,
-            'topology': self.topology,
+            'num_nodes': self.num_nodes,
             'memory': self.memory,
         }
         return descr

--- a/test/unit/config/autogen/test_autogen_common.py
+++ b/test/unit/config/autogen/test_autogen_common.py
@@ -119,7 +119,7 @@ class TestConfigAutogenCommon(unittest.TestCase):
     def test_available_memory_entire_machine(self):
         total_mem = 68719476736
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=total_mem), ulimit='unlimited'))
         avail = total_mem - hcc.parse_memory('8g')
         self.assertEqual(hcc.available_memory(node), avail)
@@ -127,14 +127,14 @@ class TestConfigAutogenCommon(unittest.TestCase):
     def test_available_memory_ulimit(self):
         total_mem = 68719476736
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=8, totalcores=24, usablecores=range(24), topology=[0],
+                cores=8, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=total_mem), ulimit='12345'))
         self.assertEqual(hcc.available_memory(node), 12345)
 
     def test_available_memory_one_third(self):
         total_mem = 68719476736
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=8, totalcores=24, usablecores=range(24), topology=[0],
+                cores=8, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=total_mem), ulimit='unlimited'))
         avail = total_mem - hcc.parse_memory('8g')
         self.assertEqual(hcc.available_memory(node), int(avail * 1./3))

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -45,7 +45,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
 
     def test_core_site_xml_defaults(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], topology=[0],
+                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736)))
         with patch('os.statvfs', return_value=MagicMock(f_bsize=4194304)):
             d = hca.core_site_xml_defaults('/', node)
@@ -57,7 +57,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
 
     def test_mapred_site_xml_defaults(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.mapred_site_xml_defaults('/', node)
         self.assertEqual(len(d), 7)
@@ -67,7 +67,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
 
     def test_yarn_site_xml_defaults(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
         self.assertEqual(len(d), 13)
@@ -81,7 +81,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
 
     def test_capacity_scheduler_xml_defaults(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.capacity_scheduler_xml_defaults('/', node)
         self.assertEqual(len(d), 6)
@@ -94,7 +94,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
         self.assertEqual(d['yarn.scheduler.capacity.root.default.acl_administer_queue'], '$user')
     def test_autogen_config(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         with patch('os.statvfs', return_value=MagicMock(f_bsize=4194304)):
             d = hca.autogen_config('/', node)

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -38,7 +38,7 @@ import hod.config.autogen.hadoop_on_lustre2 as hca
 class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
     def test_core_site_xml_defaults(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], topology=[0],
+                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736)))
         with patch('os.statvfs', return_value=MagicMock(f_bsize=4194304)):
             d = hca.core_site_xml_defaults('/', node)
@@ -52,7 +52,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
     def test_mapred_site_xml_defaults(self):
         '''Test mapred defaults; note: only using 4 from 24 cores.'''
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], topology=[0],
+                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.mapred_site_xml_defaults('/', node)
         self.assertEqual(len(d), 9)
@@ -64,7 +64,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
     def test_yarn_site_xml_defaults(self):
         '''Test yarn defaults; note: only using 4 from 24 cores.'''
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], topology=[0],
+                cores=4, totalcores=24, usablecores=[0, 1, 2, 3], num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
         self.assertEqual(len(d), 14)
@@ -76,7 +76,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
 
     def test_autogen_config(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         with patch('os.statvfs', return_value=MagicMock(f_bsize=4194304)):
             d = hca.autogen_config('/', node)

--- a/test/unit/config/autogen/test_ipython_notebook.py
+++ b/test/unit/config/autogen/test_ipython_notebook.py
@@ -29,11 +29,16 @@ Tests for IPython Notebook autoconfiguration.
 """
 
 import hod.config.autogen.ipython_notebook as hcip
+import hod.config.autogen.common as hcc
 
 import unittest
 class TestIpythonNodebook(unittest.TestCase):
-    def test_ipython_notebook_config(self):
-        cfg = hcip.ipython_notebook_config('/', {})
-        self.assertTrue(isinstance(cfg, basestring))
-        self.assertTrue(cfg.startswith("\nc = get_config()"))
-
+    def test_spark_defaults(self):
+        node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
+                    cores=16, totalcores=16, usablecores=range(16), num_nodes=6,
+                    memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
+        dflts = hcip.spark_defaults(None, node)
+        self.assertTrue(len(dflts), 3)
+        self.assertEqual(dflts['spark.executor.instances'], 17)
+        self.assertEqual(dflts['spark.executor.cores'], 5)
+        self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('18G'))

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -131,7 +131,7 @@ autogen=hadoop
         precfg = hcc.PreServiceConfigOpts(config)
         self.assertEqual(len(precfg.service_configs), 0)
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         with patch('hod.node.node.Node.go', return_value=node):
             precfg.autogen_configs()
@@ -162,7 +162,7 @@ yarn.nodemanager.hostname = 192.167.0.1
         precfg = hcc.PreServiceConfigOpts(config)
         self.assertEqual(len(precfg.service_configs), 1)
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
-                cores=24, totalcores=24, usablecores=range(24), topology=[0],
+                cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         with patch('hod.node.node.Node.go', return_value=node):
             precfg.autogen_configs()

--- a/test/unit/config/writer/test_hadoop.py
+++ b/test/unit/config/writer/test_hadoop.py
@@ -85,3 +85,17 @@ yarn.option.nested=123
                 "templated.value": "$somename"
                 }
         self.assertRaises(RuntimeError, hcw.hadoop_xml, 'file.ini', vals, tr)
+
+    def test_spark_defaults_conf(self):
+        tr = hct.TemplateResolver(somename="potato", workdir='')
+        vals = {"fs.defaultFs": "file:///",
+                "yarn.option.nested": "123",
+                "templated.value": "$somename"
+                }
+        expected = """fs.defaultFs file:///
+templated.value potato
+yarn.option.nested 123
+"""
+        output = hcw.hadoop_xml('spark-defaults.conf', vals, tr)
+        self.assertEqual(output, expected)
+


### PR DESCRIPTION
Spark defaults don't 'use everything'. Instead they are very crippled on Yarn. So we need to autogen the configs. This is a WIP to tune the defaults.

Addresses #129.