### PR TITLE
Yarn vcores

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # 3.0.3
 * Autogenerate Yarn vcore settings. Otherwise the hard coded default of '8' is
   chosen, which is not ideal.
-* Roll IPython, matplotlib, etc, modules to use intel-2015b toolchain.
 
 # 3.0.2
 * Fix for `hod batch` so it has the same environment as a shell started with

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# 3.0.3
+* Autogenerate Yarn vcore settings. Otherwise the hard coded default of '8' is
+  chosen, which is not ideal.
+* Roll IPython, matplotlib, etc, modules to use intel-2015b toolchain.
+
 # 3.0.2
 * Fix for `hod batch` so it has the same environment as a shell started with
   `hod connect`. This is required to use YARN instead of Hadoop LocalJobRunner.

--- a/etc/hod/IPython-notebook-3.2.1/hod.conf
+++ b/etc/hod/IPython-notebook-3.2.1/hod.conf
@@ -4,7 +4,7 @@
 version=1
 
 [Config]
-modules=Hadoop/2.6.0-cdh5.4.5-native,Spark/1.5.0,IPython/3.2.1-intel-2015a-Python-2.7.10,matplotlib/1.4.3-intel-2015a-Python-2.7.10
+modules=Hadoop/2.6.0-cdh5.4.5-native,Spark/1.5.0,IPython/3.2.1-intel-2015b-Python-2.7.10,matplotlib/1.4.3-intel-2015b-Python-2.7.10
 master_env=HADOOP_HOME,EBROOTHADOOP,JAVA_HOME,PYTHONPATH
 services=resourcemanager.conf,nodemanager.conf,ipython.conf,screen.conf
 config_writer=hod.config.writer.hadoop_xml

--- a/etc/hod/IPython-notebook-3.2.1/hod.conf
+++ b/etc/hod/IPython-notebook-3.2.1/hod.conf
@@ -4,6 +4,8 @@
 version=1
 
 [Config]
+# The start-notebook.sh requires IPython, matplotlib, and Spark to be loaded.
+# These are set here:
 modules=Hadoop/2.6.0-cdh5.4.5-native,Spark/1.5.0,IPython/3.2.1-intel-2015a-Python-2.7.10,matplotlib/1.4.3-intel-2015a-Python-2.7.10
 master_env=HADOOP_HOME,EBROOTHADOOP,JAVA_HOME,PYTHONPATH
 services=resourcemanager.conf,nodemanager.conf,ipython.conf,screen.conf

--- a/etc/hod/IPython-notebook-3.2.1/hod.conf
+++ b/etc/hod/IPython-notebook-3.2.1/hod.conf
@@ -4,7 +4,7 @@
 version=1
 
 [Config]
-modules=Hadoop/2.6.0-cdh5.4.5-native,Spark/1.5.0,IPython/3.2.1-intel-2015b-Python-2.7.10,matplotlib/1.4.3-intel-2015b-Python-2.7.10
+modules=Hadoop/2.6.0-cdh5.4.5-native,Spark/1.5.0,IPython/3.2.1-intel-2015a-Python-2.7.10,matplotlib/1.4.3-intel-2015a-Python-2.7.10
 master_env=HADOOP_HOME,EBROOTHADOOP,JAVA_HOME,PYTHONPATH
 services=resourcemanager.conf,nodemanager.conf,ipython.conf,screen.conf
 config_writer=hod.config.writer.hadoop_xml

--- a/etc/hod/IPython-notebook-3.2.1/start-notebook.sh
+++ b/etc/hod/IPython-notebook-3.2.1/start-notebook.sh
@@ -3,9 +3,8 @@
 # exit as soon as an error occurs
 set -e
 
-#module load IPython/3.2.1-intel-2015a-Python-2.7.10
-#module load matplotlib/1.4.3-intel-2015a-Python-2.7.10
-#module load Spark/1.5.0
+# This requires IPython, matplotlib, and Spark to be loaded. These are set in
+# the hod.conf file.
 
 ipython profile create nbserver
 

--- a/etc/hod/IPython-notebook-3.2.1/start-notebook.sh
+++ b/etc/hod/IPython-notebook-3.2.1/start-notebook.sh
@@ -3,8 +3,8 @@
 # exit as soon as an error occurs
 set -e
 
-module load IPython/3.2.1-intel-2015a-Python-2.7.10
-module load matplotlib/1.4.3-intel-2015a-Python-2.7.10
+module load IPython/3.2.1-intel-2015b-Python-2.7.10
+module load matplotlib/1.4.3-intel-2015b-Python-2.7.10
 module load Spark/1.5.0
 
 ipython profile create nbserver

--- a/etc/hod/IPython-notebook-3.2.1/start-notebook.sh
+++ b/etc/hod/IPython-notebook-3.2.1/start-notebook.sh
@@ -3,9 +3,9 @@
 # exit as soon as an error occurs
 set -e
 
-module load IPython/3.2.1-intel-2015b-Python-2.7.10
-module load matplotlib/1.4.3-intel-2015b-Python-2.7.10
-module load Spark/1.5.0
+#module load IPython/3.2.1-intel-2015a-Python-2.7.10
+#module load matplotlib/1.4.3-intel-2015a-Python-2.7.10
+#module load Spark/1.5.0
 
 ipython profile create nbserver
 

--- a/hod/__init__.py
+++ b/hod/__init__.py
@@ -29,4 +29,4 @@ Nothing here for now.
 @author: Ewan Higgs (Ghent University)
 """
 NAME = 'hanythingondemand'
-VERSION = '3.0.2'
+VERSION = '3.0.3'

--- a/hod/config/autogen/hadoop.py
+++ b/hod/config/autogen/hadoop.py
@@ -122,7 +122,7 @@ def yarn_site_xml_defaults(workdir, node_info):
     Default entries for the yarn-site.xml config file.
     '''
     mem_dflts = memory_defaults(node_info)
-
+    ncores = node_info['cores']
     max_alloc = round_mb(mem_dflts.ram_per_container * mem_dflts.num_containers)
     min_alloc = round_mb(mem_dflts.ram_per_container)
     dflts = {
@@ -139,6 +139,11 @@ def yarn_site_xml_defaults(workdir, node_info):
         'yarn.resourcemanager.webapp.https.address': '$masterhostaddress:8090',
         'yarn.resourcemanager.scheduler.class': 'org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler',
         'yarn.scheduler.capacity.allocation.file': 'capacity-scheduler.xml',
+        'yarn.app.mapreduce.am.resource.cpu-vcores': '1',
+        'yarn.scheduler.maximum-allocation-vcores': str(ncores),
+
+        'yarn.scheduler.minimum-allocation-vcores': '1',
+        'yarn.nodemanager.resource.cpu-vcores': str(ncores),
     }
     return dflts
 

--- a/hod/config/autogen/hadoop.py
+++ b/hod/config/autogen/hadoop.py
@@ -139,9 +139,7 @@ def yarn_site_xml_defaults(workdir, node_info):
         'yarn.resourcemanager.webapp.https.address': '$masterhostaddress:8090',
         'yarn.resourcemanager.scheduler.class': 'org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler',
         'yarn.scheduler.capacity.allocation.file': 'capacity-scheduler.xml',
-        'yarn.app.mapreduce.am.resource.cpu-vcores': '1',
         'yarn.scheduler.maximum-allocation-vcores': str(ncores),
-
         'yarn.scheduler.minimum-allocation-vcores': '1',
         'yarn.nodemanager.resource.cpu-vcores': str(ncores),
     }

--- a/hod/config/autogen/ipython_notebook.py
+++ b/hod/config/autogen/ipython_notebook.py
@@ -39,15 +39,18 @@ def spark_defaults(_, node_info):
 
     Defaults here are based on Cloudera's recommendations here: 
     http://blog.cloudera.com/blog/2015/03/how-to-tune-your-apache-spark-jobs-part-2/
+
+    We use 2 cores per executor based on discussion found here:
+    http://stackoverflow.com/questions/24622108/apache-spark-the-number-of-cores-vs-the-number-of-executors
     '''
     memory_defaults = hcah.memory_defaults(node_info)
     num_nodes = node_info['num_nodes']
-    cores_per_executor = 2
+    cores_per_executor = min(2, node_info['cores'])
     instances_per_node = node_info['cores'] / cores_per_executor
     # -1 because we want one less executor instance on the application master
     # If we have only one node then we don't expect the driver to be very busy, so
     # we can give the executors more memory.
-    instances = (num_nodes * instances_per_node) - 1
+    instances = max((num_nodes * instances_per_node) - 1, 1)
     memory = hcac.round_mb(memory_defaults.available_memory / instances_per_node)
     dflts = {
         'spark.executor.cores': cores_per_executor,

--- a/hod/config/autogen/ipython_notebook.py
+++ b/hod/config/autogen/ipython_notebook.py
@@ -43,15 +43,27 @@ def spark_defaults(_, node_info):
     num_nodes = node_info['num_nodes']
     instances_per_node = 3
     # -1 because we want one less executor instance on the application master
-    instances = (num_nodes * instances_per_node) - 1
     cores = (node_info['cores'] / instances_per_node)
-    memory = hcac.round_mb(memory_defaults.available_memory / instances_per_node)
-    dflts = {
-        'spark.executor.cores': cores,
-        'spark.executor.instances': instances,
-        'spark.executor.memory':  str(memory) + 'M',
-        'spark.local.dir': '$localworkdir'
-    }
+    # If we have only one node then we don't expect the driver to be very busy, so
+    # we can give the executors more memory.
+    if num_nodes == 1:
+        driver_mem = hcac.parse_memory('512M')
+        memory = hcac.round_mb((memory_defaults.available_memory - driver_mem) / instances_per_node)
+        dflts = {
+            'spark.executor.cores': cores,
+            'spark.executor.instances': instances_per_node,
+            'spark.executor.memory':  str(memory) + 'M',
+            'spark.local.dir': '$localworkdir'
+        }
+    else:
+        instances = (num_nodes * instances_per_node) - 1
+        memory = hcac.round_mb(memory_defaults.available_memory / instances_per_node)
+        dflts = {
+            'spark.executor.cores': cores,
+            'spark.executor.instances': instances,
+            'spark.executor.memory':  str(memory) + 'M',
+            'spark.local.dir': '$localworkdir'
+        }
     return dflts
 
 def autogen_config(workdir, node_info):

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -70,7 +70,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
                 cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 17)
+        self.assertEqual(len(d), 16)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], hcc.round_mb(hcc.parse_memory('56G')))
         self.assertEqual(d['yarn.resourcemanager.webapp.address'], '$masterhostaddress:8088')
         self.assertEqual(d['yarn.resourcemanager.webapp.https.address'], '$masterhostaddress:8090')
@@ -78,7 +78,6 @@ class TestConfigAutogenHadoop(unittest.TestCase):
         self.assertEqual(d['yarn.nodemanager.webapp.address'], '$hostaddress:8042')
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], hcc.round_mb(hcc.parse_memory('2G')))
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], hcc.round_mb(hcc.parse_memory('56G')))
-        self.assertEqual(d['yarn.app.mapreduce.am.resource.cpu-vcores'], '1')
         self.assertEqual(d['yarn.scheduler.maximum-allocation-vcores'], '24')
         self.assertEqual(d['yarn.scheduler.minimum-allocation-vcores'], '1')
         self.assertEqual(d['yarn.nodemanager.resource.cpu-vcores'], '24')
@@ -96,6 +95,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
                 'org.apache.hadoop.yarn.util.resource.DominantResourceCalculator')
         self.assertEqual(d['yarn.scheduler.capacity.root.default.acl_submit_applications'], '$user')
         self.assertEqual(d['yarn.scheduler.capacity.root.default.acl_administer_queue'], '$user')
+
     def test_autogen_config(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
                 cores=24, totalcores=24, usablecores=range(24), num_nodes=1,

--- a/test/unit/config/autogen/test_autogen_hadoop.py
+++ b/test/unit/config/autogen/test_autogen_hadoop.py
@@ -70,7 +70,7 @@ class TestConfigAutogenHadoop(unittest.TestCase):
                 cores=24, totalcores=24, usablecores=range(24), num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 13)
+        self.assertEqual(len(d), 17)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], hcc.round_mb(hcc.parse_memory('56G')))
         self.assertEqual(d['yarn.resourcemanager.webapp.address'], '$masterhostaddress:8088')
         self.assertEqual(d['yarn.resourcemanager.webapp.https.address'], '$masterhostaddress:8090')
@@ -78,6 +78,10 @@ class TestConfigAutogenHadoop(unittest.TestCase):
         self.assertEqual(d['yarn.nodemanager.webapp.address'], '$hostaddress:8042')
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], hcc.round_mb(hcc.parse_memory('2G')))
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], hcc.round_mb(hcc.parse_memory('56G')))
+        self.assertEqual(d['yarn.app.mapreduce.am.resource.cpu-vcores'], '1')
+        self.assertEqual(d['yarn.scheduler.maximum-allocation-vcores'], '24')
+        self.assertEqual(d['yarn.scheduler.minimum-allocation-vcores'], '1')
+        self.assertEqual(d['yarn.nodemanager.resource.cpu-vcores'], '24')
 
     def test_capacity_scheduler_xml_defaults(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -67,7 +67,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
                 cores=4, totalcores=24, usablecores=[0, 1, 2, 3], num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 14)
+        self.assertEqual(len(d), 18)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], 9216)
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], 1024)
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], 9216)

--- a/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
+++ b/test/unit/config/autogen/test_autogen_hadoop_on_lustre2.py
@@ -67,7 +67,7 @@ class TestConfigAutogenHadoopOnLustre(unittest.TestCase):
                 cores=4, totalcores=24, usablecores=[0, 1, 2, 3], num_nodes=1,
                 memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         d = hca.yarn_site_xml_defaults('/', node)
-        self.assertEqual(len(d), 18)
+        self.assertEqual(len(d), 17)
         self.assertEqual(d['yarn.nodemanager.resource.memory-mb'], 9216)
         self.assertEqual(d['yarn.scheduler.minimum-allocation-mb'], 1024)
         self.assertEqual(d['yarn.scheduler.maximum-allocation-mb'], 9216)

--- a/test/unit/config/autogen/test_ipython_notebook.py
+++ b/test/unit/config/autogen/test_ipython_notebook.py
@@ -42,3 +42,15 @@ class TestIpythonNodebook(unittest.TestCase):
         self.assertEqual(dflts['spark.executor.instances'], 17)
         self.assertEqual(dflts['spark.executor.cores'], 5)
         self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('18G'))
+
+    def test_spark_defaults_single_node(self):
+        node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
+                    cores=16, totalcores=16, usablecores=range(16), num_nodes=1,
+                    memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
+        dflts = hcip.spark_defaults(None, node)
+        self.assertTrue(len(dflts), 3)
+        self.assertEqual(dflts['spark.executor.instances'], 3)
+        self.assertEqual(dflts['spark.executor.cores'], 5)
+        memory = hcc.round_mb((hcc.parse_memory('56G') - hcc.parse_memory('512M')) / 3)
+        memory = hcc.parse_memory('%sM' % memory)
+        self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), memory)

--- a/test/unit/config/autogen/test_ipython_notebook.py
+++ b/test/unit/config/autogen/test_ipython_notebook.py
@@ -39,9 +39,9 @@ class TestIpythonNodebook(unittest.TestCase):
                     memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         dflts = hcip.spark_defaults(None, node)
         self.assertTrue(len(dflts), 3)
-        self.assertEqual(dflts['spark.executor.instances'], 17)
-        self.assertEqual(dflts['spark.executor.cores'], 5)
-        self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('18G'))
+        self.assertEqual(dflts['spark.executor.instances'], 47) # 6*8 -1
+        self.assertEqual(dflts['spark.executor.cores'], 2)
+        self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('7G'))
 
     def test_spark_defaults_single_node(self):
         node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
@@ -49,8 +49,6 @@ class TestIpythonNodebook(unittest.TestCase):
                     memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         dflts = hcip.spark_defaults(None, node)
         self.assertTrue(len(dflts), 3)
-        self.assertEqual(dflts['spark.executor.instances'], 3)
-        self.assertEqual(dflts['spark.executor.cores'], 5)
-        memory = hcc.round_mb((hcc.parse_memory('56G') - hcc.parse_memory('512M')) / 3)
-        memory = hcc.parse_memory('%sM' % memory)
-        self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), memory)
+        self.assertEqual(dflts['spark.executor.instances'], 7)
+        self.assertEqual(dflts['spark.executor.cores'], 2)
+        self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('7G'))

--- a/test/unit/config/autogen/test_ipython_notebook.py
+++ b/test/unit/config/autogen/test_ipython_notebook.py
@@ -39,7 +39,7 @@ class TestIpythonNodebook(unittest.TestCase):
                     memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
         dflts = hcip.spark_defaults(None, node)
         self.assertTrue(len(dflts), 3)
-        self.assertEqual(dflts['spark.executor.instances'], 47) # 6*8 -1
+        self.assertEqual(dflts['spark.executor.instances'], 47) # 6 nodes * 8 cores -1 core used for driver
         self.assertEqual(dflts['spark.executor.cores'], 2)
         self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('7G'))
 
@@ -52,3 +52,13 @@ class TestIpythonNodebook(unittest.TestCase):
         self.assertEqual(dflts['spark.executor.instances'], 7)
         self.assertEqual(dflts['spark.executor.cores'], 2)
         self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('7G'))
+
+    def test_spark_defaults_single_core(self):
+        node = dict(fqdn='hosty.domain.be', network='ib0', pid=1234,
+                    cores=1, totalcores=1, usablecores=range(1), num_nodes=1,
+                    memory=dict(meminfo=dict(memtotal=68719476736), ulimit='unlimited'))
+        dflts = hcip.spark_defaults(None, node)
+        self.assertTrue(len(dflts), 3)
+        self.assertEqual(dflts['spark.executor.instances'], 1)
+        self.assertEqual(dflts['spark.executor.cores'], 1)
+        self.assertEqual(hcc.parse_memory(dflts['spark.executor.memory']), hcc.parse_memory('56G'))


### PR DESCRIPTION
Yarn has a hard coded default for `DEFAULT_NM_VCORES=8;` This affects the ability of Spark to get executors spawned and hence it leaves a lot of performance on the table. This fix fixes it.

WIP because I would like to also add something for single node 'clusters' because I currently leave space in the memory allocation for the Spark Driver but I don't think it would need 1/3 of the system's memory to drive just two executors. Maybe 512M is enough to work w/ 3 executors on the single node.