### PR TITLE
Nolabel label

### DIFF
--- a/hod/local.py
+++ b/hod/local.py
@@ -84,6 +84,7 @@ def main(args):
             # if no label is specified, use job ID;
             # if $PBS_JOBID is not set, generate a random string (10 chars)
             label = os.getenv('PBS_JOBID', ''.join(random.choice(string.letters + string.digits) for _ in range(10)))
+            optparser.options.label = label
 
         _log.debug("Creating cluster info using label '%s'", label)
         cluster_info = gen_cluster_info(label, optparser.options)


### PR DESCRIPTION
When we don't set a label and the system generates one for us, we need to store it so the rest of the cluster knows what it is.