### PR TITLE
Make spark use /tmp for local dir.

### DIFF
--- a/hod/config/autogen/ipython_notebook.py
+++ b/hod/config/autogen/ipython_notebook.py
@@ -56,7 +56,7 @@ def spark_defaults(_, node_info):
         'spark.executor.cores': cores_per_executor,
         'spark.executor.instances': instances,
         'spark.executor.memory':  str(memory) + 'M',
-        'spark.local.dir': '$localworkdir',
+        'spark.local.dir': '/tmp',
     }
     return dflts
 

--- a/hod/config/autogen/ipython_notebook.py
+++ b/hod/config/autogen/ipython_notebook.py
@@ -30,6 +30,7 @@ IPython Notebook autoconfiguration.
 
 import hod.config.autogen.hadoop as hcah
 import hod.config.autogen.common as hcac
+import tempfile
 
 
 def spark_defaults(_, node_info):
@@ -56,7 +57,7 @@ def spark_defaults(_, node_info):
         'spark.executor.cores': cores_per_executor,
         'spark.executor.instances': instances,
         'spark.executor.memory':  str(memory) + 'M',
-        'spark.local.dir': '/tmp',
+        'spark.local.dir': tempfile.gettempdir(),
     }
     return dflts
 


### PR DESCRIPTION
Spark normally takes the yarn local dir. However, it does this only from the
local dir on the master node. This means all the spark executors on all the
nodes want to talk to the one hod localworkdir used by the master. This commit
changes this to use /tmp

Another solution would have been to set HOD_LOCALWORKDIR in the environments and
use {{HOD_LOCALWORKDIR}} and let spark's templating resolve it later.