### PR TITLE
add support for --modulepaths to specify the location of custom modules

### DIFF
--- a/hod/__init__.py
+++ b/hod/__init__.py
@@ -29,4 +29,4 @@ Nothing here for now.
 @author: Ewan Higgs (Ghent University)
 """
 NAME = 'hanythingondemand'
-VERSION = '3.1.0'
+VERSION = '3.1.1'

--- a/hod/cluster.py
+++ b/hod/cluster.py
@@ -46,10 +46,7 @@ CLUSTER_ENV_TEMPLATE = """
 # make sure session is properly set up (e.g., that 'module' command is defined)
 source /etc/profile
 
-for modpath in %(modpaths)s;
-do
-    module use modpath
-done
+for modpath in %(modpaths)s; do module use $modpath; done
 
 module load %(modules)s
 

--- a/hod/cluster.py
+++ b/hod/cluster.py
@@ -217,7 +217,7 @@ def gen_cluster_info(label, options):
     """Generate cluster info as a dict, intended to use as template values for CLUSTER_ENV_TEMPLATE."""
     # list of modules that should be loaded: modules for selected service + extra modules specified via --modules
     config_path = resolve_config_paths(options.hodconf, options.dist)
-    hodconf = hc.load_hod_config(config_path, options.workdir, options.modules)
+    hodconf = hc.load_hod_config(config_path, options.workdir, options.modulepaths, options.modules)
     cluster_info = {
         'hadoop_conf_dir': hodconf.configdir,
         'hod_localworkdir': hodconf.localworkdir,

--- a/hod/cluster.py
+++ b/hod/cluster.py
@@ -46,6 +46,11 @@ CLUSTER_ENV_TEMPLATE = """
 # make sure session is properly set up (e.g., that 'module' command is defined)
 source /etc/profile
 
+for modpath in %(modpaths)s;
+do
+    module use modpath
+done
+
 module load %(modules)s
 
 # set up environment
@@ -57,7 +62,7 @@ export HOD_LOCALWORKDIR='%(hod_localworkdir)s'
 echo "Welcome to your hanythingondemand cluster (label: %(label)s)"
 echo
 echo "Relevant environment variables:"
-env | egrep '^HADOOP_|^HOD_|PBS_JOBID' | sort
+env | egrep '^HADOOP_|^HOD_|PBS_JOBID|MODULEPATH' | sort
 echo
 echo "List of loaded modules:"
 module list 2>&1
@@ -220,6 +225,7 @@ def gen_cluster_info(label, options):
         'hadoop_conf_dir': hodconf.configdir,
         'hod_localworkdir': hodconf.localworkdir,
         'label': label,
+        'modpaths': ' '.join(hodconf.modulepaths),
         'modules': ' '.join(hodconf.modules),
         'workdir': options.workdir
     }

--- a/hod/hodproc.py
+++ b/hod/hodproc.py
@@ -115,7 +115,7 @@ class ConfiguredMaster(MpiService):
         """Master makes the distribution"""
         self.tasks = []
         config_path = resolve_config_paths(self.options.hodconf, self.options.dist)
-        m_config = load_hod_config(config_path, self.options.workdir, self.options.modules)
+        m_config = load_hod_config(config_path, self.options.workdir, self.options.modulepaths, self.options.modules)
         m_config.autogen_configs()
 
         resolver = _setup_template_resolver(m_config, master_template_args)
@@ -166,7 +166,7 @@ class ConfiguredSlave(MpiService):
         This only needs to run if there are more than 1 node (self.size>1)
         """
         config_path = resolve_config_paths(self.options.hodconf, self.options.dist)
-        m_config = load_hod_config(config_path, self.options.workdir, self.options.modules)
+        m_config = load_hod_config(config_path, self.options.workdir, self.options.modulepaths, self.options.modules)
         m_config.autogen_configs()
         resolver = _setup_template_resolver(m_config, master_template_args)
         _setup_config_paths(m_config, resolver)

--- a/hod/hodproc.py
+++ b/hod/hodproc.py
@@ -133,7 +133,7 @@ class ConfiguredMaster(MpiService):
             config = ConfigOpts.from_file(open(config_filename, 'r'), resolver)
             ranks_to_run = config.runs_on(MASTERRANK, range(self.size))
             self.log.debug('Adding ConfiguredService Task to work with config: %s', str(config))
-            cfg_opts = config.to_params(m_config.workdir, m_config.modules, master_template_args)
+            cfg_opts = config.to_params(m_config.workdir, m_config.modulepaths, m_config.modules, master_template_args)
             self.tasks.append(Task(ConfiguredService, config.name, ranks_to_run, cfg_opts, master_env))
 
         if hasattr(self.options, 'script') and self.options.script is not None:
@@ -147,7 +147,7 @@ class ConfiguredMaster(MpiService):
             # TODO: How can we test this?
             config = ConfigOpts(script, RUNS_ON_MASTER, '', start_script, '', master_env, resolver, timeout=NO_TIMEOUT)
             ranks_to_run = config.runs_on(MASTERRANK, range(self.size))
-            cfg_opts = config.to_params(m_config.workdir, m_config.modules, master_template_args)
+            cfg_opts = config.to_params(m_config.workdir, m_config.modulepaths, m_config.modules, master_template_args)
             self.tasks.append(Task(ConfiguredService, config.name, ranks_to_run, cfg_opts, master_env))
 
 

--- a/hod/local.py
+++ b/hod/local.py
@@ -64,6 +64,7 @@ class LocalOptions(GeneralOption):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
         opts.update({
+            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
             'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
             'script': ("Script to run on the cluster", "string", "store", None),
         })

--- a/hod/local.py
+++ b/hod/local.py
@@ -43,7 +43,7 @@ from hod.config.config import resolve_config_paths
 from hod.cluster import gen_cluster_info, save_cluster_info
 from hod.hodproc import ConfiguredSlave, ConfiguredMaster
 from hod.mpiservice import MASTERRANK, run_tasks, setup_tasks
-from hod.options import GENERAL_HOD_OPTIONS
+from hod.options import COMMON_HOD_CONFIG_OPTIONS, GENERAL_HOD_OPTIONS
 from hod.utils import only_if_module_is_available
 
 # optional packages, not always required
@@ -63,9 +63,8 @@ class LocalOptions(GeneralOption):
     def config_options(self):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
+        opts.update(COMMON_HOD_CONFIG_OPTIONS)
         opts.update({
-            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
-            'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
             'script': ("Script to run on the cluster", "string", "store", None),
         })
         descr = ["Local configuration", "Configuration options for the 'genconfig' subcommand"]

--- a/hod/options.py
+++ b/hod/options.py
@@ -31,6 +31,11 @@ Hanythingondemand main program.
 """
 from vsc.utils import fancylogger
 
+COMMON_HOD_CONFIG_OPTIONS = {
+    'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
+    'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
+}
+
 GENERAL_HOD_OPTIONS = {
     'dist': ("Prepackaged Hadoop distribution (e.g.  Hadoop/2.5.0-cdh5.3.1-native). "
              "This cannot be set if --hodconf is set", 'string', 'store', None),

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -40,7 +40,7 @@ from vsc.utils.generaloption import GeneralOption
 
 import hod.cluster as hc
 from hod import VERSION as HOD_VERSION
-from hod.options import GENERAL_HOD_OPTIONS, RESOURCE_MANAGER_OPTIONS, validate_pbs_option
+from hod.options import COMMON_HOD_CONFIG_OPTIONS, GENERAL_HOD_OPTIONS, RESOURCE_MANAGER_OPTIONS, validate_pbs_option
 from hod.rmscheduler.hodjob import PbsHodJob
 from hod.subcommands.subcommand import SubCommand
 
@@ -69,10 +69,7 @@ class BatchOptions(GeneralOption):
     def config_options(self):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
-        opts.update({
-            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
-            'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
-        })
+        opts.update(COMMON_HOD_CONFIG_OPTIONS)
         descr = ["Batch job creation configuration", "Configuration options for the 'batch' subcommand"]
 
         self.log.debug("Add config option parser descr %s opts %s", descr, opts)

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -70,6 +70,7 @@ class BatchOptions(GeneralOption):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
         opts.update({
+            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
             'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
         })
         descr = ["Batch job creation configuration", "Configuration options for the 'batch' subcommand"]

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -38,7 +38,7 @@ from vsc.utils.generaloption import GeneralOption
 
 import hod.cluster as hc
 from hod import VERSION as HOD_VERSION
-from hod.options import GENERAL_HOD_OPTIONS, RESOURCE_MANAGER_OPTIONS, validate_pbs_option
+from hod.options import COMMON_HOD_CONFIG_OPTIONS, GENERAL_HOD_OPTIONS, RESOURCE_MANAGER_OPTIONS, validate_pbs_option
 from hod.rmscheduler.hodjob import PbsHodJob
 from hod.subcommands.subcommand import SubCommand
 
@@ -63,10 +63,7 @@ class CreateOptions(GeneralOption):
     def config_options(self):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
-        opts.update({
-            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
-            'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
-        })
+        opts.update(COMMON_HOD_CONFIG_OPTIONS)
         descr = ["Create configuration", "Configuration options for the 'create' subcommand"]
 
         self.log.debug("Add config option parser descr %s opts %s", descr, opts)

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -64,6 +64,7 @@ class CreateOptions(GeneralOption):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
         opts.update({
+            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
             'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
         })
         descr = ["Create configuration", "Configuration options for the 'create' subcommand"]

--- a/hod/subcommands/genconfig.py
+++ b/hod/subcommands/genconfig.py
@@ -54,6 +54,7 @@ class GenConfigOptions(GeneralOption):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
         opts.update({
+            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
             'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
         })
         descr = ["Genconfig configuration", "Configuration options for the 'genconfig' subcommand"]

--- a/hod/subcommands/genconfig.py
+++ b/hod/subcommands/genconfig.py
@@ -38,7 +38,7 @@ from vsc.utils.generaloption import GeneralOption
 from hod import VERSION as HOD_VERSION
 from hod.hodproc import ConfiguredMaster
 from hod.mpiservice import setup_tasks
-from hod.options import GENERAL_HOD_OPTIONS, validate_required_option
+from hod.options import COMMON_HOD_CONFIG_OPTIONS, GENERAL_HOD_OPTIONS, validate_required_option
 from hod.subcommands.subcommand import SubCommand
 from hod.utils import setup_diagnostic_environment
 
@@ -53,10 +53,7 @@ class GenConfigOptions(GeneralOption):
     def config_options(self):
         """Add general configuration options."""
         opts = copy.deepcopy(GENERAL_HOD_OPTIONS)
-        opts.update({
-            'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
-            'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
-        })
+        opts.update(COMMON_HOD_CONFIG_OPTIONS)
         descr = ["Genconfig configuration", "Configuration options for the 'genconfig' subcommand"]
 
         self.log.debug("Add config option parser descr %s opts %s", descr, opts)

--- a/hod/subcommands/helptemplate.py
+++ b/hod/subcommands/helptemplate.py
@@ -49,8 +49,8 @@ class HelpTemplateOptions(GeneralOption):
 def mk_registry():
     """Make a TemplateRegistry and register basic items"""
     config_opts = ConfigOptsParams('svc-name', 'MASTER', 'ExecPreStart', 'ExecStart', 'ExecStop',
-                                   dict(), workdir='WORKDIR', modules=['MODULES'], master_template_kwargs=[],
-                                   timeout=COMMAND_TIMEOUT)
+                                   dict(), workdir='WORKDIR', modulepaths=['MODULEPATHS'],
+                                   modules=['MODULES'], master_template_kwargs=[], timeout=COMMAND_TIMEOUT)
     reg = hct.TemplateRegistry()
     hct.register_templates(reg, config_opts)
     master_template_kwargs = master_template_opts(reg.fields.values())

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -341,7 +341,7 @@ ExecStop=stopper
 [Environment]
 SOME_ENV=123""")
         cfg = hcc.ConfigOpts.from_file(config, hct.TemplateResolver(workdir=''))
-        cfgparams = cfg.to_params('workdir', 'modules', dict(master='template_args'))
+        cfgparams = cfg.to_params('workdir', 'modulepaths', 'modules', dict(master='template_args'))
         remade_cfg = loads(dumps(cfgparams))
         self.assertEqual(cfgparams.name, remade_cfg.name)
         self.assertEqual(cfgparams.start_script, remade_cfg.start_script)
@@ -365,7 +365,7 @@ SOME_ENV=123""")
         self.assertEqual(cfg.start_script, '$MYPATH/starter')
         self.assertEqual(cfg.stop_script, '$MYPATH/stopper')
 
-        params = cfg.to_params(workdir='', modules='', master_template_args=dict())
+        params = cfg.to_params(workdir='', modulepaths='', modules='', master_template_args=dict())
         cfg2 = hcc.ConfigOpts.from_params(params, hct.TemplateResolver(workdir=''))
         self.assertEqual(cfg2.start_script, '$MYPATH/starter')
         self.assertEqual(cfg2.stop_script, '$MYPATH/stopper')


### PR DESCRIPTION
Users can already support additional modules to be loaded via `--modules`, but these are expected to be available by default in whichever `$MODULEPATH` that gets defined.

With Lmod as a modules tool, specifying the modules to be loaded full path doesn't work.

By adding `--modulepaths` and running `module use` on each of them, users can specify additional locations for modules to be loaded.