### PR TITLE
fix passing down of modulepaths into HOD job

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# 3.1.2
+* also take --modulepaths into account for HOD jobs (not just for interactive sessions)
+
+# 3.1.1
+* add support for --modulepaths to specify the location of custom modules
+
+# 3.1.0
+* add dist with IPython 4.2.0
+* add Travis configuration
+
 # 3.0.4
 * IPython 3.2.3 with Spark 1.6 is now bundled as an available distribution.
 * Faster startup time on multiple nodes.

--- a/hod/__init__.py
+++ b/hod/__init__.py
@@ -29,4 +29,4 @@ Nothing here for now.
 @author: Ewan Higgs (Ghent University)
 """
 NAME = 'hanythingondemand'
-VERSION = '3.1.1'
+VERSION = '3.1.2'

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -128,6 +128,9 @@ class PbsHodJob(MympirunHod):
         # If the user mistypes the --dist argument (e.g. Haddoop-...) then this will
         # raise; TODO: cleanup the error reporting. 
         precfg = PreServiceConfigOpts.from_file_list(config_filenames, workdir=options.options.workdir)
+        for modulepath in precfg.modulepaths:
+            self.log.debug("Adding extra module path '%s' to startup script", modulepath)
+            self.modulepaths.append(modulepath)
         for module in precfg.modules:
             self.log.debug("Adding '%s' module to startup script.", module)
             self.modules.append(module)

--- a/hod/rmscheduler/job.py
+++ b/hod/rmscheduler/job.py
@@ -45,6 +45,7 @@ class Job(object):
 
         self.type = None
 
+        self.modulepaths = []
         self.modules = []
 
         self.run_in_cwd = True
@@ -104,6 +105,11 @@ class Job(object):
         Generate the module statements. Returns a list.
         Elements that are string or 1 long are assumed to be load requests
         """
+        cmds = []
+
+        for mp in self.modulepaths:
+            cmds.append("module use %s" % mp)
+
         allmods = []
         for md in self.modules:
             if type(md) in (str,):
@@ -117,7 +123,9 @@ class Job(object):
                 self.log.error("Unknown module type %s (%s)", type(md), md)
 
         self.log.debug("Going to generate string for modules %s", allmods)
-        return ['module %s' % (" ".join(md)) for md in allmods]
+        cmds.extend(['module %s' % (" ".join(md)) for md in allmods])
+
+        return cmds
 
     @classmethod
     def _is_job_for(cls, name):


### PR DESCRIPTION
this was missing from #161 to ensure that the `--modulepaths` is also taken into account for HOD jobs (not just for interactive sessions)