### PR TITLE
also consider additional modules and module paths passed via command line options

### DIFF
--- a/hod/__init__.py
+++ b/hod/__init__.py
@@ -30,4 +30,4 @@
 @author: Kenneth Hoste (Ghent University)
 """
 NAME = 'hanythingondemand'
-VERSION = '3.1.3'
+VERSION = '3.1.4'

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -127,7 +127,9 @@ class PbsHodJob(MympirunHod):
         self.log.info('Loading "%s" manifest config', config_filenames)
         # If the user mistypes the --dist argument (e.g. Haddoop-...) then this will
         # raise; TODO: cleanup the error reporting. 
-        precfg = PreServiceConfigOpts.from_file_list(config_filenames, workdir=options.options.workdir)
+        precfg = PreServiceConfigOpts.from_file_list(config_filenames, workdir=options.options.workdir,
+                                                     modulepaths=options.options.modulepaths,
+                                                     modules=options.options.modules)
         for modulepath in precfg.modulepaths:
             self.log.debug("Adding extra module path '%s' to startup script", modulepath)
             self.modulepaths.append(modulepath)


### PR DESCRIPTION
The fixes in #161 and #162 were incomplete in the sense that only additional module paths specified in a custom `hod.conf` file are being picked up, not those that are specified via `--modulepaths`; same applies to `--modules`.

This patch fixes that problem.