### PR TITLE
include list of modules corresponding to each dist in 'hod dists' output

### DIFF
--- a/hod/subcommands/dists.py
+++ b/hod/subcommands/dists.py
@@ -31,7 +31,7 @@ List available distributions known to hanythingondemand.
 """
 from vsc.utils.generaloption import GeneralOption
 
-from hod.config.config import avail_dists
+from hod.config.config import avail_dists, load_service_config, resolve_dist_path
 from hod.subcommands.subcommand import SubCommand
 
 
@@ -42,5 +42,9 @@ class DistsSubCommand(SubCommand):
 
     def run(self, args):
         """Run 'dists' subcommand."""
-        print '\n'.join(avail_dists())
-        return 0
+        dists = avail_dists()
+        for dist in dists:
+            cfg_fp = open(resolve_dist_path(dist))
+            modules = load_service_config(cfg_fp).get('Config', 'modules').split(',')
+            cfg_fp.close()
+            print "%s (modules: %s)" % (dist, ', '.join(modules))

--- a/hod/subcommands/dists.py
+++ b/hod/subcommands/dists.py
@@ -42,9 +42,15 @@ class DistsSubCommand(SubCommand):
 
     def run(self, args):
         """Run 'dists' subcommand."""
+        lines = []
         dists = avail_dists()
         for dist in dists:
             cfg_fp = open(resolve_dist_path(dist))
             modules = load_service_config(cfg_fp).get('Config', 'modules').split(',')
             cfg_fp.close()
-            print "%s (modules: %s)" % (dist, ', '.join(modules))
+            lines.extend([
+                "* %s" % dist,
+                "    modules: %s" % ', '.join(modules),
+                '',
+            ])
+        print '\n'.join(lines)

--- a/hod/subcommands/dists.py
+++ b/hod/subcommands/dists.py
@@ -29,10 +29,15 @@ List available distributions known to hanythingondemand.
 @author: Ewan Higgs (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
+import sys
+from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 from hod.config.config import avail_dists, load_service_config, resolve_dist_path
 from hod.subcommands.subcommand import SubCommand
+
+
+_log = fancylogger.getLogger('dists', fname=False)
 
 
 class DistsSubCommand(SubCommand):
@@ -45,9 +50,13 @@ class DistsSubCommand(SubCommand):
         lines = []
         dists = avail_dists()
         for dist in dists:
-            cfg_fp = open(resolve_dist_path(dist))
-            modules = load_service_config(cfg_fp).get('Config', 'modules').split(',')
-            cfg_fp.close()
+            try:
+                cfg_fp = open(resolve_dist_path(dist))
+                modules = load_service_config(cfg_fp).get('Config', 'modules').split(',')
+                cfg_fp.close()
+            except IOError as err:
+                _log.error("Failed to get list of modules for dist '%s': %s", dist, err)
+
             lines.extend([
                 "* %s" % dist,
                 "    modules: %s" % ', '.join(modules),

--- a/hod/subcommands/dists.py
+++ b/hod/subcommands/dists.py
@@ -50,6 +50,7 @@ class DistsSubCommand(SubCommand):
         lines = []
         dists = avail_dists()
         for dist in dists:
+            modules = None
             try:
                 cfg_fp = open(resolve_dist_path(dist))
                 modules = load_service_config(cfg_fp).get('Config', 'modules').split(',')
@@ -57,10 +58,10 @@ class DistsSubCommand(SubCommand):
             except IOError as err:
                 _log.error("Failed to get list of modules for dist '%s': %s", dist, err)
 
-            lines.extend([
-                "* %s" % dist,
-                "    modules: %s" % ', '.join(modules),
-                '',
-            ])
+            lines.append("* " + dist)
+            if modules:
+                lines.append("    modules: " + ', '.join(modules))
+            lines.append('')
+
         print '\n'.join(lines)
         return 0

--- a/hod/subcommands/dists.py
+++ b/hod/subcommands/dists.py
@@ -54,3 +54,4 @@ class DistsSubCommand(SubCommand):
                 '',
             ])
         print '\n'.join(lines)
+        return 0

--- a/hod/subcommands/dists.py
+++ b/hod/subcommands/dists.py
@@ -57,11 +57,13 @@ class DistsSubCommand(SubCommand):
                 cfg_fp.close()
             except IOError as err:
                 _log.error("Failed to get list of modules for dist '%s': %s", dist, err)
+                continue
 
-            lines.append("* " + dist)
-            if modules:
-                lines.append("    modules: " + ', '.join(modules))
-            lines.append('')
+            lines.extend([
+                "* %s" % dist,
+                "    modules: %s" % ', '.join(modules),
+                '',
+            ])
 
         print '\n'.join(lines)
         return 0

--- a/test/unit/subcommands/test_subcommands_dists.py
+++ b/test/unit/subcommands/test_subcommands_dists.py
@@ -38,8 +38,9 @@ class TestDistsSubCommand(unittest.TestCase):
     def test_run(self):
         app = DistsSubCommand()
         with patch('os.listdir', return_value=['Hadoop-1.2.3']):
-            with capture(app.run, []) as (out, err):
-                self.assertTrue('Hadoop-1.2.3' in out)
+            with patch('open', return_value=['[Config]\nmodules=Hadoop/1.2.3']):
+                with capture(app.run, []) as (out, err):
+                    self.assertTrue('* Hadoop-1.2.3\n    modules: Hadoop/1.2.3' in out)
 
     def test_usage(self):
         app = DistsSubCommand()

--- a/test/unit/subcommands/test_subcommands_dists.py
+++ b/test/unit/subcommands/test_subcommands_dists.py
@@ -29,6 +29,7 @@
 
 import unittest
 import pytest
+from cStringIO import StringIO
 from mock import patch
 from ..util import capture
 from hod.subcommands.dists import DistsSubCommand
@@ -37,8 +38,9 @@ from hod.subcommands.dists import DistsSubCommand
 class TestDistsSubCommand(unittest.TestCase):
     def test_run(self):
         app = DistsSubCommand()
+        mocked_fp = StringIO("[Config]\nmodules=Hadoop/1.2.3")
         with patch('os.listdir', return_value=['Hadoop-1.2.3']):
-            with patch('open', return_value=['[Config]\nmodules=Hadoop/1.2.3']):
+            with patch('__builtin__.open', return_value=mocked_fp):
                 with capture(app.run, []) as (out, err):
                     self.assertTrue('* Hadoop-1.2.3\n    modules: Hadoop/1.2.3' in out)
 


### PR DESCRIPTION
current output doesn't provide enough information on what a dist includes exactly:

```
$ hod dists
HBase-1.0.2
Hadoop-2.3.0-cdh5.0.0
Hadoop-2.5.0-cdh5.3.1-gpfs
Hadoop-2.5.0-cdh5.3.1-native
Hadoop-2.6.0-cdh5.4.5-native
Hadoop-on-lustre2
IPython-notebook-3.2.1
IPython-notebook-3.2.3
IPython-notebook-4.2.0
Jupyter-notebook-5.1.0
```

revamped info:
```
$ hod dists
* HBase-1.0.2
    modules: HBase/1.0.2, Hadoop/2.6.0-cdh5.4.5-native

* Hadoop-2.3.0-cdh5.0.0
    modules: Hadoop/2.3.0-cdh5.0.0

* Hadoop-2.5.0-cdh5.3.1-gpfs
    modules: Hadoop/2.5.0-cdh5.3.1

* Hadoop-2.5.0-cdh5.3.1-native
    modules: Hadoop/2.5.0-cdh5.3.1-native

* Hadoop-2.6.0-cdh5.4.5-native
    modules: Hadoop/2.6.0-cdh5.4.5-native

* Hadoop-on-lustre2
    modules: Hadoop/2.4.0-seagate-722af1-native

* IPython-notebook-3.2.1
    modules: Hadoop/2.6.0-cdh5.4.5-native, Spark/1.5.0, IPython/3.2.1-intel-2015a-Python-2.7.10, matplotlib/1.4.3-intel-2015a-Python-2.7.10

* IPython-notebook-3.2.3
    modules: Hadoop/2.6.0-cdh5.4.5-native, Spark/1.6.0, IPython/3.2.3-intel-2015b-Python-2.7.10, matplotlib/1.4.3-intel-2015b-Python-2.7.10

* IPython-notebook-4.2.0
    modules: Hadoop/2.6.0-cdh5.7.0-native, Spark/1.6.1, IPython/4.2.0-intel-2016a-Python-2.7.11, matplotlib/1.5.1-intel-2016a-Python-2.7.11

* Jupyter-notebook-5.1.0
    modules: Hadoop/2.6.0-cdh5.8.0-native, Spark/2.0.0, IPython/5.1.0-intel-2016b-Python-2.7.12, matplotlib/1.5.1-intel-2016b-Python-2.7.12
```