### PR TITLE
stop using deprecated .message on exceptions

### DIFF
--- a/hod/config/template.py
+++ b/hod/config/template.py
@@ -126,20 +126,20 @@ def _current_user():
     '''
     return pwd.getpwuid(os.getuid()).pw_name
 
-def resolve_config_str(s, **template_kwargs):
+def resolve_config_str(tmpl_str, **template_kwargs):
     '''
     Given a string, resolve the templates based on template_dict and
     template_kwargs.
 
     If a non string is provided, the original value is returned.
     '''
-    if not isinstance(s, basestring):
-        return s
-    template = string.Template(s)
+    if not isinstance(tmpl_str, basestring):
+        return tmpl_str
+    template = string.Template(tmpl_str)
     try:
         retval = template.substitute(template_kwargs)
-    except TypeError, e:
-        raise TypeError('Error processing "%s": %s' % (str(s), e.message))
+    except TypeError as err:
+        raise TypeError('Error processing "%s": %s' % (tmpl_str, err))
     return retval
 
 class TemplateResolver(object):
@@ -152,6 +152,6 @@ class TemplateResolver(object):
         self._template_kwargs = template_kwargs
         self._template_kwargs.update(os.environ)
 
-    def __call__(self, s):
+    def __call__(self, tmpl_str):
         '''Given a string with template placeholders, return the resolved string'''
-        return resolve_config_str(s, **self._template_kwargs)
+        return resolve_config_str(tmpl_str, **self._template_kwargs)

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -122,7 +122,7 @@ class BatchSubCommand(SubCommand):
             jobs = j.state()
             hc.post_job_submission(label, jobs, optparser.options.workdir)
             return 0
-        except StandardError as e:
+        except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(e.message)
+            _log.raiseException(err)

--- a/hod/subcommands/clean.py
+++ b/hod/subcommands/clean.py
@@ -64,4 +64,4 @@ class CleanSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err.message)
+            _log.raiseException(err)

--- a/hod/subcommands/connect.py
+++ b/hod/subcommands/connect.py
@@ -78,8 +78,8 @@ class ConnectSubCommand(SubCommand):
             try:
                 jobid = cluster_jobid(label)
                 env_script = cluster_env_file(label)
-            except ValueError as e:
-                _log.error(e.message)
+            except ValueError as err:
+                _log.error(err)
                 sys.exit(1)
 
             print "Job ID found: %s" % jobid
@@ -115,4 +115,4 @@ class ConnectSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err.message)
+            _log.raiseException(err)

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -99,7 +99,7 @@ class CreateSubCommand(SubCommand):
             jobs = j.state()
             hc.post_job_submission(label, jobs, optparser.options.workdir)
             return 0
-        except StandardError as e:
+        except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(e.message)
+            _log.raiseException(err)

--- a/hod/subcommands/listcmd.py
+++ b/hod/subcommands/listcmd.py
@@ -87,5 +87,5 @@ class ListSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err.message)
+            _log.raiseException(err)
         return 0

--- a/hod/subcommands/relabel.py
+++ b/hod/subcommands/relabel.py
@@ -59,21 +59,20 @@ class RelabelSubCommand(SubCommand):
         optparser = RelabelOptions(go_args=args, envvar_prefix=self.envvar_prefix, usage=self.usage_txt)
         try:
             if len(optparser.args) != 3:
-                sys.stderr.write(self.usage())
+                _log.error(self.usage())
                 sys.exit(1)
 
             labels = hc.known_cluster_labels()
             if optparser.args[1] not in labels:
-                sys.stderr.write('Cluster with label "%s" not found\n' % optparser.args[1])
+                _log.error("Cluster with label '%s' not found", optparser.args[1])
                 sys.exit(1)
             try:
                 hc.mv_cluster_info(optparser.args[1], optparser.args[2])
             except (IOError, OSError) as err:
-                sys.stderr.write('Could not change label "%s" to "%s": "%s"\n' %
-                    (optparser.args[1], optparser.args[2], err.message))
+                _log.error("Could not change label '%s' to '%s': %s", optparser.args[1], optparser.args[2], err)
                 sys.exit(1)
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err.message)
+            _log.raiseException(err)
         return 0


### PR DESCRIPTION
Current output on a faulty `hod connect`:

```
$ hod connect foo26345
Connecting to HOD cluster with label 'foo26345'...
/gpfs/scratch/projects/project_gpilot/vsc40023/software/hanythingondemand/3.2.0dev-cli/lib/python2.6/site-packages/hanythingondemand-3.1.4-py2.6.egg/hod/subcommands/connect.py:82: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
2016-10-20 11:36:40,859 ERROR      not available in optimized mode MainThread  No 'env' file found for cluster with label 'foo26345'
```

with this patch included, the deprecation warning is gone, leading to a much clearer error message (although there's room for further improvement, especially the 'not available in optimized mode' bit):

```
$ hod connect foo26345
Connecting to HOD cluster with label 'foo26345'...
2016-10-20 11:45:46,207 ERROR      not available in optimized mode MainThread  No 'env' file found for cluster with label 'foo26345'
```