### PR TITLE
implement support for 'destroy' subcommand

### DIFF
--- a/docs/Command_line_interface.rst
+++ b/docs/Command_line_interface.rst
@@ -24,7 +24,7 @@ Running ``hod`` without arguments is equivalent to ``hod --help``, and results i
 .. code::
 
     $ hod
-    hanythingondemand version 3.0.0 - Run services within an HPC cluster
+    hanythingondemand version 3.2.0 - Run services within an HPC cluster
     usage: hod <subcommand> [subcommand options]
     Available subcommands (one of these must be specified!):
         batch           Submit a job to spawn a cluster on a PBS job controller, run a job script, and tear down the cluster when it's done
@@ -32,6 +32,7 @@ Running ``hod`` without arguments is equivalent to ``hod --help``, and results i
         clone           Write hod configs to a directory for editing purposes.
         connect         Connect to a hod cluster.
         create          Submit a job to spawn a cluster on a PBS job controller
+        destroy         Destroy an HOD cluster.
         dists           List the available distributions
         genconfig       Write hod configs to a directory for diagnostic purposes
         help-template   Print the values of the configuration templates based on the current machine.
@@ -84,6 +85,7 @@ Available subcommands:
 * :ref:`cmdline_clone`
 * :ref:`cmdline_connect`
 * :ref:`cmdline_create`
+* :ref:`cmdline_destroy`
 * :ref:`cmdline_dists`
 * :ref:`cmdline_genconfig`
 * :ref:`cmdline_helptemplate`
@@ -153,6 +155,19 @@ Jobs that have completed will remain in the output of ``hod list`` with a job id
 is run (see :ref:`cmdline_clean`).
 
 .. note:: ``--hod-module``, ``--workdir``, and either ``--hodconf`` or ``--dist`` must be specified.
+
+
+.. _cmdline_destroy:
+
+``hod destroy <cluster-label>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Destroy the HOD cluster with the specified label.
+
+This involves deleting the job, and removing the working directory and cluster info directory
+(``$HOME/.config/hod.d/<label>``) corresponding to this cluster, if they are still in place.
+
+In case the cluster is currently *running*, confirmation will be requested.
 
 
 .. _cmdline_create_options:

--- a/hod/main.py
+++ b/hod/main.py
@@ -32,7 +32,7 @@ Hanythingondemand main program.
 import sys
 
 import hod
-from hod.subcommands import (batch, connect, clean, clone, create, dists, genconfig,
+from hod.subcommands import (batch, connect, clean, clone, create, destroy, dists, genconfig,
         helptemplate, listcmd, relabel)
 
 
@@ -42,6 +42,7 @@ SUBCOMMANDS = [
     clone.CloneSubCommand,
     connect.ConnectSubCommand,
     create.CreateSubCommand,
+    destroy.DestroySubCommand,
     dists.DistsSubCommand,
     genconfig.GenConfigSubCommand,
     helptemplate.HelpTemplateSubCommand,

--- a/hod/rmscheduler/rm_pbs.py
+++ b/hod/rmscheduler/rm_pbs.py
@@ -280,6 +280,8 @@ class Pbs(ResourceManagerScheduler):
         else:
             self.log.debug("Succesfully deleted job %s", jobid)
 
+        return result == 0
+
     def header(self):
         """Return the script header that requests the properties.
            nodes = number of nodes

--- a/hod/rmscheduler/rm_pbs.py
+++ b/hod/rmscheduler/rm_pbs.py
@@ -274,7 +274,7 @@ class Pbs(ResourceManagerScheduler):
         if jobid is None:
             jobid = self.jobid
 
-        result = pbs.pbs_deljob(self.pbsconn, self.jobid, '')  # use empty string, not NULL (one can pass the deldelay=nnnn option)
+        result = pbs.pbs_deljob(self.pbsconn, jobid, '')  # use empty string, not NULL (one can pass the deldelay=nnnn option)
         if result:
             self.log.error("Failed to delete job %s: error %s", jobid, result)
         else:

--- a/hod/subcommands/connect.py
+++ b/hod/subcommands/connect.py
@@ -46,7 +46,7 @@ import hod.rmscheduler.rm_pbs as rm_pbs
 _log = fancylogger.getLogger(fname=False)
 
 class ConnectOptions(GeneralOption):
-    """Option parser for 'destroy' subcommand."""
+    """Option parser for 'connect' subcommand."""
     VERSION = hod.VERSION
     ALLOPTSMANDATORY = False # let us use optionless arguments.
 

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -107,6 +107,10 @@ class DestroySubCommand(SubCommand):
                     print "(destruction aborted)"
                     return
 
+            elif job_state in ['C', 'E']:
+                print "(job has already ended/completed)"
+                job_state = None
+
             print "\nStarting actual destruction of HOD cluster with label '%s'...\n" % label
 
             # actually destroy HOD cluster by deleting job and removing cluster info dir and local work dir

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -100,11 +100,14 @@ class DestroySubCommand(SubCommand):
                 _log.error("Multiple jobs found with job ID '%s': %s", jobid, pbsjobs)
                 sys.exit(1)
 
+            # request confirmation is case the job is currently running
             if job_state == 'R':
-                resp = raw_input("Confirm destroying the *running* HOD cluster with label '%s'? [y/n]: ", label)
+                resp = raw_input("Confirm destroying the *running* HOD cluster with label '%s'? [y/n]: " % label)
                 if resp != 'y':
                     print "(destruction aborted)"
                     return
+
+            print "\nStarting actual destruction of HOD cluster with label '%s'...\n" % label
 
             # actually destroy HOD cluster by deleting job and removing cluster info dir and local work dir
             if job_state is not None:

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -65,21 +65,21 @@ class DestroySubCommand(SubCommand):
         """Run 'destroy' subcommand."""
         optparser = DestroyOptions(go_args=args, envvar_prefix=self.envvar_prefix, usage=self.usage_txt)
         try:
+            label, jobid = None, None
+
             if len(optparser.args) > 1:
                 label = optparser.args[1]
+                print "Destroying HOD cluster with label '%s'..." % label
             else:
                 _log.error("No label provided.")
                 sys.exit(1)
 
-            print "Destroying HOD cluster with label '%s'..." % label
-
             try:
                 jobid = cluster_jobid(label)
+                print "Job ID: %s" % jobid
             except ValueError as e:
                 _log.error(e.message)
                 sys.exit(1)
-
-            print "Job ID: %s" % jobid
 
             # try to figure out job state
             job_state = None
@@ -108,7 +108,9 @@ class DestroySubCommand(SubCommand):
 
             # actually destroy HOD cluster by deleting job and removing cluster info dir and local work dir
             if job_state is not None:
-                pbs.remove(jobid)
+                # if job was not successfully deleted, pbs.remove will print an error message
+                if pbs.remove(jobid):
+                    print "Job with ID %s deleted." % jobid
 
             rm_cluster_localworkdir(label)
 

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -77,8 +77,8 @@ class DestroySubCommand(SubCommand):
             try:
                 jobid = cluster_jobid(label)
                 print "Job ID: %s" % jobid
-            except ValueError as e:
-                _log.error(e.message)
+            except ValueError as err:
+                _log.error(err)
                 sys.exit(1)
 
             # try to figure out job state
@@ -125,4 +125,4 @@ class DestroySubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err.message)
+            _log.raiseException(err)


### PR DESCRIPTION
Example usage:

* running job:
```
$ hod destroy foo21570
Destroying HOD cluster with label 'foo21570'...
Job ID: 736167.master-moab.muk.os
Job status: R
Confirm destroying the *running* HOD cluster with label 'foo21570'? [y/n]: n
(destruction aborted)
```
```
$ hod destroy foo21570
Destroying HOD cluster with label 'foo21570'...
Job ID: 736167.master-moab.muk.os
Job status: R
Confirm destroying the *running* HOD cluster with label 'foo21570'? [y/n]: y

Starting actual destruction of HOD cluster with label 'foo21570'...

Job with ID 736167.master-moab.muk.os deleted.
Removed cluster localworkdir directory /gpfs/scratch/users/vsc400/vsc40023/hod/736167.master-moab.muk.os for cluster labeled foo21570
Removed cluster info directory /user/home/gent/vsc400/vsc40023/.config/hod.d/foo21570 for cluster labeled foo21570

HOD cluster with label 'foo21570' (job ID: 736167.master-moab.muk.os) destroyed.
```

* queued job:
```
$ hod destroy foo17156
Destroying HOD cluster with label 'foo17156'...
Job ID: 736166.master-moab.muk.os
Job status: Q

Starting actual destruction of HOD cluster with label 'foo17156'...

Job with ID 736166.master-moab.muk.os deleted.
Note: No local workdir /gpfs/scratch/users/vsc400/vsc40023/hod/736166.master-moab.muk.os found for cluster foo17156; job was deleted before it started running?
Removed cluster info directory /user/home/gent/vsc400/vsc40023/.config/hod.d/foo17156 for cluster labeled foo17156

HOD cluster with label 'foo17156' (job ID: 736166.master-moab.muk.os) destroyed.
```