### PR TITLE
pass string rather than Exception instance as argument to raiseException

### DIFF
--- a/hod/__init__.py
+++ b/hod/__init__.py
@@ -30,4 +30,4 @@
 @author: Kenneth Hoste (Ghent University)
 """
 NAME = 'hanythingondemand'
-VERSION = '3.2.0'
+VERSION = '3.2.1'

--- a/hod/main.py
+++ b/hod/main.py
@@ -77,8 +77,7 @@ def main(args):
     """Parse options and run specified subcommand."""
     subcmd, args = init_subcmd(args)
     if subcmd is not None:
-        subcmd.run(args)
-        return 0
+        return subcmd.run(args)
 
     elif len([arg for arg in args if not arg.startswith('-')]) > 1:
         sys.stderr.write("ERROR: No known subcommand specified\n")

--- a/hod/main.py
+++ b/hod/main.py
@@ -77,7 +77,8 @@ def main(args):
     """Parse options and run specified subcommand."""
     subcmd, args = init_subcmd(args)
     if subcmd is not None:
-        return subcmd.run(args)
+        subcmd.run(args)
+        return 0
 
     elif len([arg for arg in args if not arg.startswith('-')]) > 1:
         sys.stderr.write("ERROR: No known subcommand specified\n")

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -125,4 +125,4 @@ class BatchSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err)
+            _log.raiseException(str(err))

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -121,3 +121,5 @@ class BatchSubCommand(SubCommand):
             hc.post_job_submission(label, jobs, optparser.options.workdir)
         except StandardError as err:
             self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/batch.py
+++ b/hod/subcommands/batch.py
@@ -35,7 +35,6 @@ import os
 import stat
 import sys
 
-from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 import hod.cluster as hc
@@ -44,7 +43,6 @@ from hod.options import COMMON_HOD_CONFIG_OPTIONS, GENERAL_HOD_OPTIONS, RESOURCE
 from hod.rmscheduler.hodjob import PbsHodJob
 from hod.subcommands.subcommand import SubCommand
 
-_log = fancylogger.getLogger('batch', fname=False)
 
 class BatchOptions(GeneralOption):
     VERSION = HOD_VERSION
@@ -121,8 +119,5 @@ class BatchSubCommand(SubCommand):
             j.run()
             jobs = j.state()
             hc.post_job_submission(label, jobs, optparser.options.workdir)
-            return 0
         except StandardError as err:
-            fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
-            fancylogger.logToScreen(enable=True)
-            _log.raiseException(str(err))
+            self._log_and_raise(err)

--- a/hod/subcommands/clean.py
+++ b/hod/subcommands/clean.py
@@ -27,18 +27,15 @@
 Remove stale .hod.d/* files.
 
 @author: Ewan Higgs (Universiteit Gent)
+@author: Kenneth Hoste (Universiteit Gent)
 """
 
-from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 from hod import VERSION as HOD_VERSION
 from hod.subcommands.subcommand import SubCommand
 import hod.cluster as hc
 import hod.rmscheduler.rm_pbs as rm_pbs
-
-
-_log = fancylogger.getLogger(fname=False)
 
 
 class CleanOptions(GeneralOption):
@@ -62,6 +59,4 @@ class CleanSubCommand(SubCommand):
             info = hc.mk_cluster_info_dict(labels, state, master=rm_master)
             hc.clean_cluster_info(rm_master, info)
         except StandardError as err:
-            fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
-            fancylogger.logToScreen(enable=True)
-            _log.raiseException(str(err))
+            self._log_and_raise(err)

--- a/hod/subcommands/clean.py
+++ b/hod/subcommands/clean.py
@@ -64,4 +64,4 @@ class CleanSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err)
+            _log.raiseException(str(err))

--- a/hod/subcommands/clean.py
+++ b/hod/subcommands/clean.py
@@ -60,3 +60,5 @@ class CleanSubCommand(SubCommand):
             hc.clean_cluster_info(rm_master, info)
         except StandardError as err:
             self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/clone.py
+++ b/hod/subcommands/clone.py
@@ -77,8 +77,7 @@ class CloneSubCommand(SubCommand):
                 sys.stderr.write('Error: Input dist not found: "%s".\n' % dist)
                 sys.exit(1)
             shutil.copytree(src, output_dir)
-            return 0
-        except Exception as err:
-            _log.error("Failed to copy dist: %s", str(err))
-            _log.exception("hod clone failed")
-            sys.exit(1)
+        except StandardError as err:
+            self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/connect.py
+++ b/hod/subcommands/connect.py
@@ -115,4 +115,4 @@ class ConnectSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err)
+            _log.raiseException(str(err))

--- a/hod/subcommands/connect.py
+++ b/hod/subcommands/connect.py
@@ -105,3 +105,5 @@ class ConnectSubCommand(SubCommand):
 
         except StandardError as err:
             self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -102,4 +102,4 @@ class CreateSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err)
+            _log.raiseException(str(err))

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -28,12 +28,12 @@ Generate a PBS job script using pbs_python. Will use mympirun to get the all sta
 
 @author: Stijn De Weirdt (Universiteit Gent)
 @author: Ewan Higgs (Universiteit Gent)
+@author: Kenneth Hoste (Ghent University)
 """
 import os
 import copy
 import sys
 
-from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 import hod.cluster as hc
@@ -41,9 +41,6 @@ from hod import VERSION as HOD_VERSION
 from hod.options import COMMON_HOD_CONFIG_OPTIONS, GENERAL_HOD_OPTIONS, RESOURCE_MANAGER_OPTIONS, validate_pbs_option
 from hod.rmscheduler.hodjob import PbsHodJob
 from hod.subcommands.subcommand import SubCommand
-
-
-_log = fancylogger.getLogger('create', fname=False)
 
 
 class CreateOptions(GeneralOption):
@@ -98,8 +95,5 @@ class CreateSubCommand(SubCommand):
             j.run()
             jobs = j.state()
             hc.post_job_submission(label, jobs, optparser.options.workdir)
-            return 0
         except StandardError as err:
-            fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
-            fancylogger.logToScreen(enable=True)
-            _log.raiseException(str(err))
+            self._log_and_raise(err)

--- a/hod/subcommands/create.py
+++ b/hod/subcommands/create.py
@@ -97,3 +97,5 @@ class CreateSubCommand(SubCommand):
             hc.post_job_submission(label, jobs, optparser.options.workdir)
         except StandardError as err:
             self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -122,3 +122,5 @@ class DestroySubCommand(SubCommand):
 
         except StandardError as err:
             self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -129,4 +129,4 @@ class DestroySubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err)
+            _log.raiseException(str(err))

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -31,7 +31,6 @@ Destroy an HOD cluster.
 import os
 import sys
 
-from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 import hod
@@ -39,8 +38,6 @@ import hod.rmscheduler.rm_pbs as rm_pbs
 from hod.cluster import cluster_info_exists, cluster_jobid, rm_cluster_info, rm_cluster_localworkdir
 from hod.subcommands.subcommand import SubCommand
 
-
-_log = fancylogger.getLogger('destroy', fname=False)
 
 
 class DestroyOptions(GeneralOption):
@@ -71,15 +68,13 @@ class DestroySubCommand(SubCommand):
                 label = optparser.args[1]
                 print "Destroying HOD cluster with label '%s'..." % label
             else:
-                _log.error("No label provided.")
-                sys.exit(1)
+                self.report_error("No label provided.")
 
             try:
                 jobid = cluster_jobid(label)
                 print "Job ID: %s" % jobid
             except ValueError as err:
-                _log.error(err)
-                sys.exit(1)
+                self.report_error(err)
 
             # try to figure out job state
             job_state = None
@@ -97,8 +92,7 @@ class DestroySubCommand(SubCommand):
                 print "(job no longer found)"
 
             else:
-                _log.error("Multiple jobs found with job ID '%s': %s", jobid, pbsjobs)
-                sys.exit(1)
+                self.report_error("Multiple jobs found with job ID '%s': %s", jobid, pbsjobs)
 
             # request confirmation is case the job is currently running
             if job_state == 'R':
@@ -127,6 +121,4 @@ class DestroySubCommand(SubCommand):
             print "\nHOD cluster with label '%s' (job ID: %s) destroyed." % (label, jobid)
 
         except StandardError as err:
-            fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
-            fancylogger.logToScreen(enable=True)
-            _log.raiseException(str(err))
+            self._log_and_raise(err)

--- a/hod/subcommands/genconfig.py
+++ b/hod/subcommands/genconfig.py
@@ -80,8 +80,7 @@ class GenConfigSubCommand(SubCommand):
         svc = ConfiguredMaster(optparser.options)
         try:
             setup_tasks(svc)
-            return 0
-        except Exception as e:
-            _log.error("Failed to setup hod tasks: %s", str(e))
-            _log.exception("hod genconfig failed")
-            sys.exit(1)
+        except StandardError as err:
+            self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/helptemplate.py
+++ b/hod/subcommands/helptemplate.py
@@ -85,3 +85,5 @@ class HelpTemplateSubCommand(SubCommand):
         headers = ('Parameter name', 'Value', 'Documentation')
         formatted_rows = format_rows(reg.fields, resolver)
         print ht.format_table(formatted_rows, headers)
+
+        return 0

--- a/hod/subcommands/listcmd.py
+++ b/hod/subcommands/listcmd.py
@@ -27,12 +27,12 @@
 List the running applications.
 
 @author: Ewan Higgs (Universiteit Gent)
+@author: Kenneth Hoste (Universiteit Gent)
 """
 
 import sys
 from itertools import chain
 
-from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 from hod import VERSION as HOD_VERSION
@@ -40,9 +40,6 @@ from hod.subcommands.subcommand import SubCommand
 import hod.cluster as hc
 import hod.table as ht
 import hod.rmscheduler.rm_pbs as rm_pbs
-
-
-_log = fancylogger.getLogger(fname=False)
 
 
 class ListOptions(GeneralOption):
@@ -85,7 +82,4 @@ class ListSubCommand(SubCommand):
             info_rows = format_list_rows(info)
             print ht.format_table(info_rows, headers)
         except StandardError as err:
-            fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
-            fancylogger.logToScreen(enable=True)
-            _log.raiseException(str(err))
-        return 0
+            self._log_and_raise(err)

--- a/hod/subcommands/listcmd.py
+++ b/hod/subcommands/listcmd.py
@@ -83,3 +83,5 @@ class ListSubCommand(SubCommand):
             print ht.format_table(info_rows, headers)
         except StandardError as err:
             self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/listcmd.py
+++ b/hod/subcommands/listcmd.py
@@ -87,5 +87,5 @@ class ListSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err)
+            _log.raiseException(str(err))
         return 0

--- a/hod/subcommands/relabel.py
+++ b/hod/subcommands/relabel.py
@@ -74,5 +74,5 @@ class RelabelSubCommand(SubCommand):
         except StandardError as err:
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
-            _log.raiseException(err)
+            _log.raiseException(str(err))
         return 0

--- a/hod/subcommands/relabel.py
+++ b/hod/subcommands/relabel.py
@@ -68,3 +68,5 @@ class RelabelSubCommand(SubCommand):
                 self.report_error("Could not change label '%s' to '%s': %s", optparser.args[1], optparser.args[2], err)
         except StandardError as err:
             self._log_and_raise(err)
+
+        return 0

--- a/hod/subcommands/relabel.py
+++ b/hod/subcommands/relabel.py
@@ -27,19 +27,16 @@
 Relabel a cluster.
 
 @author: Ewan Higgs (Universiteit Gent)
+@author: Kenneth Hoste (Universiteit Gent)
 """
 
 import sys
 
-from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
 from hod import VERSION as HOD_VERSION
 from hod.subcommands.subcommand import SubCommand
 import hod.cluster as hc
-
-
-_log = fancylogger.getLogger(fname=False)
 
 
 class RelabelOptions(GeneralOption):
@@ -59,20 +56,15 @@ class RelabelSubCommand(SubCommand):
         optparser = RelabelOptions(go_args=args, envvar_prefix=self.envvar_prefix, usage=self.usage_txt)
         try:
             if len(optparser.args) != 3:
-                _log.error(self.usage())
-                sys.exit(1)
+                self.report_error(self.usage())
 
             labels = hc.known_cluster_labels()
             if optparser.args[1] not in labels:
-                _log.error("Cluster with label '%s' not found", optparser.args[1])
-                sys.exit(1)
+                self.report_error("Cluster with label '%s' not found", optparser.args[1])
+
             try:
                 hc.mv_cluster_info(optparser.args[1], optparser.args[2])
             except (IOError, OSError) as err:
-                _log.error("Could not change label '%s' to '%s': %s", optparser.args[1], optparser.args[2], err)
-                sys.exit(1)
+                self.report_error("Could not change label '%s' to '%s': %s", optparser.args[1], optparser.args[2], err)
         except StandardError as err:
-            fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
-            fancylogger.logToScreen(enable=True)
-            _log.raiseException(str(err))
-        return 0
+            self._log_and_raise(err)

--- a/hod/subcommands/subcommand.py
+++ b/hod/subcommands/subcommand.py
@@ -60,9 +60,9 @@ class SubCommand(object):
         fancylogger.logToScreen(enable=True)
         self.log.raiseException(str(err))
 
-    def report_error(self, msg):
+    def report_error(self, msg, *args):
         """Report error and exit"""
-        self.log.error(msg)
+        self.log.error(msg, *args)
         sys.exit(1)
 
     @abstractmethod

--- a/hod/subcommands/subcommand.py
+++ b/hod/subcommands/subcommand.py
@@ -28,8 +28,11 @@ Abstract base class for subcommand support.
 
 @author: Ewan Higgs (Universiteit Gent)
 """
-
+import sys
 from abc import abstractmethod
+
+from vsc.utils import fancylogger
+
 
 class SubCommand(object):
     """Abstract base class for subcommand support."""
@@ -42,6 +45,7 @@ class SubCommand(object):
         """Class constructor."""
         self.envvar_prefix = 'HOD_%s' % self.CMD.upper().replace('-', '_')
         self.usage_txt = 'hod %s [options]' % self.CMD
+        self.log = fancylogger.getLogger(name=self.__class__.__name__, fname=False)
 
     def usage(self):
         """Return usage of this subcommand."""
@@ -49,6 +53,17 @@ class SubCommand(object):
         if self.EXAMPLE:
             usage += "hod %s %s\n" % (self.CMD, self.EXAMPLE)
         return usage
+
+    def _log_and_raise(self, err):
+        """Report error that occured, and raise Exception"""
+        fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
+        fancylogger.logToScreen(enable=True)
+        self.log.raiseException(str(err))
+
+    def report_error(self, msg):
+        """Report error and exit"""
+        self.log.error(msg)
+        sys.exit(1)
 
     @abstractmethod
     def run(self, args):


### PR DESCRIPTION
fix for this nasty traceback, which hides the actual problem (some `ImportError`):

```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/apps/gent/SL6/sandybridge/software/hanythingondemand/3.2.0-cli/lib/python2.6/site-packages/hanythingondemand-3.2.0-py2.6.egg/hod/main.py", line 92, in <module>
  File "/apps/gent/SL6/sandybridge/software/hanythingondemand/3.2.0-cli/lib/python2.6/site-packages/hanythingondemand-3.2.0-py2.6.egg/hod/main.py", line 80, in main
  File "/apps/gent/SL6/sandybridge/software/hanythingondemand/3.2.0-cli/lib/python2.6/site-packages/hanythingondemand-3.2.0-py2.6.egg/hod/subcommands/listcmd.py", line 90, in run
  File "/usr/lib/python2.7/site-packages/vsc/utils/fancylogger.py", line 322, in raiseException
    message += " (%s)" % detail
TypeError: unsupported operand type(s) for +=: 'exceptions.ImportError' and 'str'
```