### PR TITLE
make sure both Python 2.6 and Python 2.7 are available in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
+python:
+    - '2.6'
+    - '2.7'
 before_install:
     - sudo apt-get update && sudo apt-get install -y python-dev torque-server libtorque2-dev libopenmpi-dev openmpi-bin
 install:
     - pip install --upgrade pip
     - pip install tox
 script:
-    - tox
+    - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)


### PR DESCRIPTION
This seems to be required now due to updates in the Travis environment (cfr. https://blog.travis-ci.com/2017-05-04-precise-image-updates)

Otherwise, tests fail with:

```
ERROR:   py26: InterpreterNotFound: python2.6
```