### PR TITLE
fix log statements in destroy/dists subcommands

### DIFF
--- a/hod/subcommands/clone.py
+++ b/hod/subcommands/clone.py
@@ -40,9 +40,6 @@ from hod import VERSION as HOD_VERSION
 from hod.subcommands.subcommand import SubCommand
 
 
-_log = fancylogger.getLogger('clone', fname=False)
-
-
 class CloneOptions(GeneralOption):
     """Option parser for 'clone' subcommand."""
     VERSION = HOD_VERSION

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -82,7 +82,7 @@ class DestroySubCommand(SubCommand):
             pbs = rm_pbs.Pbs(optparser)
             jobs = pbs.state()
             pbsjobs = [job for job in jobs if job.jobid == jobid]
-            _log.debug("Matching jobs for job ID '%s': %s", jobid, pbsjobs)
+            self.log.debug("Matching jobs for job ID '%s': %s", jobid, pbsjobs)
 
             if len(pbsjobs) == 1:
                 job_state = pbsjobs[0].state 

--- a/hod/subcommands/dists.py
+++ b/hod/subcommands/dists.py
@@ -37,9 +37,6 @@ from hod.config.config import avail_dists, load_service_config, resolve_dist_pat
 from hod.subcommands.subcommand import SubCommand
 
 
-_log = fancylogger.getLogger('dists', fname=False)
-
-
 class DistsSubCommand(SubCommand):
     """Implementation of HOD 'dists' subcommand."""
     CMD = 'dists'
@@ -56,7 +53,7 @@ class DistsSubCommand(SubCommand):
                 modules = load_service_config(cfg_fp).get('Config', 'modules').split(',')
                 cfg_fp.close()
             except IOError as err:
-                _log.error("Failed to get list of modules for dist '%s': %s", dist, err)
+                self.log.error("Failed to get list of modules for dist '%s': %s", dist, err)
                 continue
 
             lines.extend([

--- a/hod/subcommands/genconfig.py
+++ b/hod/subcommands/genconfig.py
@@ -43,9 +43,6 @@ from hod.subcommands.subcommand import SubCommand
 from hod.utils import setup_diagnostic_environment
 
 
-_log = fancylogger.getLogger('genconfig', fname=False)
-
-
 class GenConfigOptions(GeneralOption):
     """Option parser for 'genconfig' subcommand."""
     VERSION = HOD_VERSION


### PR DESCRIPTION
& get rid of unused _log in clone/genconfig

fix for issue triggered via `hod destroy`, introduced in #191

```
$ hod destroy ipython_example
Destroying HOD cluster with label 'ipython_example'...
Job ID: 3255163.master15.delcatty.gent.vsc
2017-05-08 08:43:17,138 WARNING    not available in optimized mode.DestroySubCommand MainThread  global name '_log' is not defined (global name '_log' is not defined
  File "build/bdist.linux-x86_64/egg/hod/subcommands/destroy.py", line 85, in run
    _log.debug("Matching jobs for job ID '%s': %s", jobid, pbsjobs)
)
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "build/bdist.linux-x86_64/egg/hod/main.py", line 92, in <module>
    # applications use their own logger, we need to tell them to debug or not
  File "build/bdist.linux-x86_64/egg/hod/main.py", line 80, in main
    from easybuild.framework.easyconfig import EasyConfig
  File "build/bdist.linux-x86_64/egg/hod/subcommands/destroy.py", line 124, in run
  File "build/bdist.linux-x86_64/egg/hod/subcommands/subcommand.py", line 61, in _log_and_raise
  File "build/bdist.linux-x86_64/egg/hod/subcommands/destroy.py", line 85, in run
NameError: global name '_log' is not defined (global name '_log' is not defined)
```