### PR TITLE
add support for running HoD on top of Slurm, and make it the default resource manager (HPC-7164)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 python:
     - '2.6'
     - '2.7'

--- a/hod/__init__.py
+++ b/hod/__init__.py
@@ -30,4 +30,4 @@
 @author: Kenneth Hoste (Ghent University)
 """
 NAME = 'hanythingondemand'
-VERSION = '3.2.3'
+VERSION = '4.0.0'

--- a/hod/cluster.py
+++ b/hod/cluster.py
@@ -289,7 +289,7 @@ def clean_cluster_info(master, cluster_info):
     master, but no job info founs.
     """
     for info in cluster_info:
-        if info.pbsjob is None and info.jobid.endswith(master):
+        if info.pbsjob is None and (master is None or info.jobid.endswith(master)):
             rm_cluster_localworkdir(info.label)
             rm_cluster_info(info.label)
 

--- a/hod/cluster.py
+++ b/hod/cluster.py
@@ -66,7 +66,8 @@ module list 2>&1
 """
 
 
-ClusterInfo = namedtuple('ClusterInfo', 'label, jobid, pbsjob')
+ClusterInfo = namedtuple('ClusterInfo', 'label, jobid, job')
+
 
 def is_valid_label(label):
     """
@@ -96,6 +97,7 @@ def validate_label(label, known_labels):
 
     return True
 
+
 def validate_hodconf_or_dist(hodconf, dist):
     """
     Returns true if either the hodconf or the dist can be resolved successfully.
@@ -107,6 +109,7 @@ def validate_hodconf_or_dist(hodconf, dist):
         _log.error(e)
         return False
     return True
+
 
 def report_cluster_submission(label):
     """
@@ -146,6 +149,7 @@ def known_cluster_labels():
 
     return res
 
+
 def _cluster_info(label, info_file):
     """
     Return path to specified cluster info file for cluster with specified label.
@@ -173,17 +177,17 @@ def cluster_workdir(label):
     return os.path.expandvars(open(_cluster_info(label, 'workdir')).read())
 
 
-def _find_pbsjob(jobid, pbsjobs):
-    for job in pbsjobs:
+def _find_job(jobid, jobs):
+    for job in jobs:
         if jobid == job.jobid:
             return job
     return None
 
 
-def mk_cluster_info_dict(labels, pbsjobs, master=None):
+def mk_cluster_info_dict(labels, jobs, master=None):
     """
-    Given a list of labels and PbsJobs, construct a dict of list of tuples
-    mapping label to PbsJob.
+    Given a list of labels and jobs, construct a dict of list of tuples
+    mapping label to job.
     """
     info = []
     seen_jobs = set()
@@ -194,7 +198,7 @@ def mk_cluster_info_dict(labels, pbsjobs, master=None):
             jobid = cluster_jobid(label)
             if master is not None and not jobid.endswith(master):
                 continue
-            job = _find_pbsjob(jobid, pbsjobs)
+            job = _find_job(jobid, jobs)
             if job is not None:
                 seen_jobs.add(jobid)
         except ValueError as err:
@@ -289,7 +293,7 @@ def clean_cluster_info(master, cluster_info):
     master, but no job info founs.
     """
     for info in cluster_info:
-        if info.pbsjob is None and (master is None or info.jobid.endswith(master)):
+        if info.job is None and (master is None or info.jobid.endswith(master)):
             rm_cluster_localworkdir(info.label)
             rm_cluster_info(info.label)
 

--- a/hod/cluster.py
+++ b/hod/cluster.py
@@ -196,15 +196,18 @@ def mk_cluster_info_dict(labels, jobs, master=None):
     for label in labels:
         try:
             jobid = cluster_jobid(label)
+            _log.debug("Job ID for cluster '%s': %s", label, jobid)
             if master is not None and not jobid.endswith(master):
                 continue
             job = _find_job(jobid, jobs)
+            _log.debug("Job for job ID %s: %s", jobid, job)
             if job is not None:
                 seen_jobs.add(jobid)
         except ValueError as err:
             _log.error("Exception occured when fetching cluster info for cluster with label '%s': %s", label, err)
             jobid, job = None, None
         info.append(ClusterInfo(label, jobid, job))
+        _log.debug("Cluster info for '%s': %s", label, info[-1])
 
     return info
 

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -211,7 +211,16 @@ class Sbatch(Command):
 
     def __init__(self, script):
         Command.__init__(self)
-        self.command = ['sbatch', '--export=NONE', '--chdir=%s' % os.getenv('HOME'), script]
+        home = os.getenv('HOME')
+        cwd = os.getcwd()
+        self.command = [
+            'sbatch',
+            '--export=NONE',
+            '--chdir=%s' % home,
+            '--error=%s' % os.path.join(cwd, '%x.e%A'),
+            '--output=%s' % os.path.join(cwd, '%x.o%A'),
+            script,
+        ]
 
 
 class Scancel(Command):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -195,6 +195,15 @@ class ULimit(Command):
         Command.__init__(self)
         self.command = ['ulimit', flag]
 
+
+class Squeue(Command):
+    """Run 'squeue -o %all' and return output."""
+
+    def __init__(self):
+        Command.__init__(self)
+        self.command = ['squeue', '-o', '%all']
+
+
 class ScreenDaemon(Command):
     """Start a named screen session in background"""
     def __init__(self, name):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -243,6 +243,14 @@ class Scancel(Command):
         self.command = ['scancel', jobid]
 
 
+class Sinfo(Command):
+    """Wrapper for 'sinfo <args>'."""
+
+    def __init__(self, *args):
+        Command.__init__(self)
+        self.command = ['sinfo'] + list(args)
+
+
 class ScreenDaemon(Command):
     """Start a named screen session in background"""
     def __init__(self, name):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -197,11 +197,19 @@ class ULimit(Command):
 
 
 class Squeue(Command):
-    """Run 'squeue -o %all' and return output."""
+    """Wrapper for 'squeue -o %all'."""
 
     def __init__(self):
         Command.__init__(self)
         self.command = ['squeue', '-o', '%all']
+
+
+class Sbatch(Command):
+    """Wrapper for 'sbatch <script>'."""
+
+    def __init__(self, script):
+        Command.__init__(self)
+        self.command = ['sbatch', script]
 
 
 class ScreenDaemon(Command):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -199,9 +199,11 @@ class ULimit(Command):
 class Squeue(Command):
     """Wrapper for 'squeue -o %all'."""
 
-    def __init__(self):
+    def __init__(self, jobid=None):
         Command.__init__(self)
         self.command = ['squeue', '-o', '%all']
+        if jobid:
+            self.command.append('--jobs=%s' % ','.join(jobid))
 
 
 class Sbatch(Command):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -214,6 +214,14 @@ class Sbatch(Command):
         self.command = ['sbatch', script]
 
 
+class Scancel(Command):
+    """Wrapper for 'scancel <jobid>'."""
+
+    def __init__(self, jobid):
+        Command.__init__(self)
+        self.command = ['scancel', jobid]
+
+
 class ScreenDaemon(Command):
     """Start a named screen session in background"""
     def __init__(self, name):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -203,7 +203,7 @@ class Squeue(Command):
         Command.__init__(self)
         self.command = ['squeue', '-o', '%all']
         if jobid:
-            self.command.append('--jobs=%s' % ','.join(jobid))
+            self.command.append('--jobs=%s' % jobid)
 
 
 class Sbatch(Command):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -211,7 +211,7 @@ class Sbatch(Command):
 
     def __init__(self, script):
         Command.__init__(self)
-        self.command = ['sbatch', script]
+        self.command = ['sbatch', '--export=NONE', '--chdir=%s' % os.getenv('HOME'), script]
 
 
 class Scancel(Command):

--- a/hod/commands/command.py
+++ b/hod/commands/command.py
@@ -217,6 +217,7 @@ class Sbatch(Command):
             'sbatch',
             '--export=NONE',
             '--chdir=%s' % home,
+            '--get-user-env=60L',
             '--error=%s' % os.path.join(cwd, '%x.e%A'),
             '--output=%s' % os.path.join(cwd, '%x.o%A'),
             script,

--- a/hod/options.py
+++ b/hod/options.py
@@ -47,15 +47,15 @@ GENERAL_HOD_OPTIONS = {
 }
 
 RESOURCE_MANAGER_OPTIONS = {
-    'walltime': ("Job walltime in hours", 'float', 'store', 48, 'l'),
-    'nodes': ("Full nodes for the job", "int", "store", 1, "n"),
-    'ppn': ("Processors per node (-1=full node)", "int", "store", -1),
+    'account': ("Account name (empty string is default Account)", "string", "store", "", "A"),
     'mail': ("When to send mail (b=begin, e=end, a=abort)", "string", "extend", [], "m"),
     'mailothers': ("Other email adresses to send mail to", "string", "extend", [], "M"),
-    'queue': ("Queue name (empty string is default queue)", "string", "store", "", "q"),
+    'nodes': ("Full nodes for the job", "int", "store", 1, "n"),
     'partition': ("Partition name (empty string is default partition)", "string", "store", "", "p"),
-    'account': ("Account name (empty string is default Account)", "string", "store", "", "A"),
+    'ppn': ("Processors per node (-1=full node)", "int", "store", -1),
+    'queue': ("Queue name (empty string is default queue)", "string", "store", "", "q"),
     'reservation': ("ID of reservation to submit job into", 'string', 'store', ''),
+    'walltime': ("Job walltime in hours", 'float', 'store', 48, 'l'),
 }
 
 _log = fancylogger.getLogger('create', fname=False)

--- a/hod/options.py
+++ b/hod/options.py
@@ -31,12 +31,16 @@ Hanythingondemand main program.
 """
 from vsc.utils import fancylogger
 
+PBS = 'PBS'
+SLURM = 'Slurm'
+
 COMMON_HOD_CONFIG_OPTIONS = {
     'modulepaths': ("Extra paths to take into account for loading modules", 'string', 'store', None),
     'modules': ("Extra modules to load in each service environment", 'string', 'store', None),
 }
 
 GENERAL_HOD_OPTIONS = {
+    'rm-backend': ("Resource manager 'backend' to use", 'choice', 'store', SLURM, [PBS, SLURM]),
     'dist': ("Prepackaged Hadoop distribution (e.g.  Hadoop/2.5.0-cdh5.3.1-native). "
              "This cannot be set if --hodconf is set", 'string', 'store', None),
     'hodconf': ("Top level configuration file. This can be a comma separated list of config files with "
@@ -60,6 +64,7 @@ RESOURCE_MANAGER_OPTIONS = {
 
 _log = fancylogger.getLogger('create', fname=False)
 
+
 def validate_required_option(options):
     """pbs options require a config and a workdir"""
     if not options.hodconf and not options.dist:
@@ -73,6 +78,7 @@ def validate_required_option(options):
         return False
 
     return True
+
 
 def validate_pbs_option(options):
     """pbs options require a config and a workdir"""

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -59,7 +59,9 @@ class HodJob(Job):
                 self.hodargs[idx] = regex.sub(r'=\1', hodarg)
                 self.log.info("tweaked hod argument: %s", self.hodargs[idx])
 
-        self.hodenvvarprefix = ['HOD', 'PBS']
+        # any environment variables required by services must be listed here (strictly requires in Slurm environment?),
+        # to avoid passing down empty environment variables...
+        self.hodenvvarprefix = ['HOD', 'PBS', 'EBROOTHADOOP', 'EBROOTHBASE', 'HADOOP_HOME', 'JAVA_HOME']
 
         self.set_type_class()
 

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -59,7 +59,7 @@ class HodJob(Job):
                 self.hodargs[idx] = regex.sub(r'=\1', hodarg)
                 self.log.info("tweaked hod argument: %s", self.hodargs[idx])
 
-        # any environment variables required by services must be listed here (strictly requires in Slurm environment?),
+        # any environment variables required by services must be listed here (strictly required in Slurm environment?),
         # to avoid passing down empty environment variables...
         self.hodenvvarprefix = ['HOD', 'PBS', 'SLURM', 'HOME', 'USER',
                                 'EBROOTHADOOP', 'EBROOTHBASE', 'HADOOP_HOME', 'JAVA_HOME']

--- a/hod/rmscheduler/hodjob.py
+++ b/hod/rmscheduler/hodjob.py
@@ -61,7 +61,8 @@ class HodJob(Job):
 
         # any environment variables required by services must be listed here (strictly requires in Slurm environment?),
         # to avoid passing down empty environment variables...
-        self.hodenvvarprefix = ['HOD', 'PBS', 'EBROOTHADOOP', 'EBROOTHBASE', 'HADOOP_HOME', 'JAVA_HOME']
+        self.hodenvvarprefix = ['HOD', 'PBS', 'SLURM', 'HOME', 'USER',
+                                'EBROOTHADOOP', 'EBROOTHBASE', 'HADOOP_HOME', 'JAVA_HOME']
 
         self.set_type_class()
 

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -98,8 +98,6 @@ class Slurm(ResourceManagerScheduler):
         f.close()
 
         stdout, stderr = Sbatch(scriptfn).run()
-        print 'stdout: %s' % stdout
-        print 'stderr: %s' % stderr
         if stderr:
             raise RuntimeError("Job submission failed: %s" % stderr)
 
@@ -194,9 +192,12 @@ class Slurm(ResourceManagerScheduler):
 
         # get list of all jobs
         jobs = self.list_jobs()
+        self.log.debug("List of jobs before filtering: %s", jobs)
 
         # filter based on job ID
+        self.log.debug("Filtering with jobid %s (type %s)", jobid, type(jobid))
         jobs = [j for j in jobs if j['JOBID'] == jobid]
+        self.log.debug("List of jobs after filtering: %s", jobs)
 
         res = []
         for job in jobs:

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -188,11 +188,15 @@ class Slurm(ResourceManagerScheduler):
 
         # only known filter is based on job name
         job_name_filter = job_filter.pop('Job_Name', None)
+        self.log.debug("Job name filter: %s" % job_name_filter)
         if job_filter:
             raise NotImplementedError("Unknown job filter keys encountered: %s" % job_filter.keys())
 
-        # get list of jobs
+        # get list of all jobs
         jobs = self.list_jobs()
+
+        # filter based on job ID
+        jobs = [j for j in jobs if j['JOBID'] == jobid]
 
         res = []
         for job in jobs:

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -145,11 +145,11 @@ class Slurm(ResourceManagerScheduler):
         jobs = [SlurmJob(j, s, h) for (j, s, h) in zip(jid, jstate, map(_first_or_blank, ehosts))]
         return jobs
 
-    def list_jobs(self):
+    def list_jobs(self, jobid=None):
         """Return list of currently queued/running jobs."""
 
         # https://gist.github.com/stevekm/7831fac98473ea17d781330baa0dd7aa
-        stdout, _ = Squeue().run()
+        stdout, _ = Squeue(jobid).run()
 
         # expected format:
         # CLUSTER: cluster_name
@@ -191,13 +191,8 @@ class Slurm(ResourceManagerScheduler):
             raise NotImplementedError("Unknown job filter keys encountered: %s" % job_filter.keys())
 
         # get list of all jobs
-        jobs = self.list_jobs()
+        jobs = self.list_jobs(jobid)
         self.log.debug("List of jobs before filtering: %s", jobs)
-
-        # filter based on job ID
-        self.log.debug("Filtering with jobid %s (type %s)", jobid, type(jobid))
-        jobs = [j for j in jobs if j['JOBID'] == jobid]
-        self.log.debug("List of jobs after filtering: %s", jobs)
 
         res = []
         for job in jobs:

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -29,6 +29,7 @@ Implementation of the Slurm resource manager
 """
 import os
 import re
+import sys
 import tempfile
 from vsc.utils import fancylogger
 
@@ -149,7 +150,9 @@ class Slurm(ResourceManagerScheduler):
         """Return list of currently queued/running jobs."""
 
         # https://gist.github.com/stevekm/7831fac98473ea17d781330baa0dd7aa
-        stdout, _ = Squeue(jobid).run()
+        stdout, stderr = Squeue(jobid).run()
+        if stderr:
+            raise RuntimeError("squeue failed: %s" % stderr)
 
         # expected format:
         # CLUSTER: cluster_name
@@ -211,6 +214,8 @@ class Slurm(ResourceManagerScheduler):
             jobid = self.jobid
 
         stdout, stderr = Scancel(jobid).run()
+        if stderr:
+            sys.stderr.write("scancel failed: %s\n" % stderr)
 
         # return True if removal was successful
         return not stderr

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -226,6 +226,7 @@ class Slurm(ResourceManagerScheduler):
         mail = self.options.get('mail', [])
         mail_others = self.options.get('mailothers', [])
         reservation = self.options.get('reservation', None)
+        name = self.options.get('name', 'hod')
 
         self.log.debug("nodes %s, ppn %s, walltime %s, mail %s, mail_others %s",
                        nodes, ppn, walltime, mail, mail_others)
@@ -242,6 +243,7 @@ class Slurm(ResourceManagerScheduler):
                        nodes, ppn, walltimetxt)
 
         self.args = {
+            'job-name': name,
             'nodes': nodes,
             'ntasks-per-node': ppn,
             'time': walltimetxt,

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -32,7 +32,7 @@ import re
 import tempfile
 from vsc.utils import fancylogger
 
-from hod.commands.command import Sbatch, Squeue
+from hod.commands.command import Sbatch, Scancel, Squeue
 from hod.rmscheduler.resourcemanagerscheduler import ResourceManagerScheduler
 
 
@@ -210,9 +210,10 @@ class Slurm(ResourceManagerScheduler):
         if jobid is None:
             jobid = self.jobid
 
-        raise NotImplementedError
+        stdout, stderr = Scancel(jobid).run()
 
-        return False  # FIXME return True if removal worked
+        # return True if removal was successful
+        return not stderr
 
     def header(self):
         """Return the script header that requests the properties.

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -1,0 +1,247 @@
+# #
+# Copyright 2019-2019 Ghent University
+#
+# This file is part of hanythingondemand
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/hanythingondemand
+#
+# hanythingondemand is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# hanythingondemand is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hanythingondemand. If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Implementation of the Slurm resource manager
+
+@author: Kenneth Hoste (Ghent University)
+"""
+import os
+import tempfile
+from vsc.utils import fancylogger
+
+from hod.rmscheduler.resourcemanagerscheduler import ResourceManagerScheduler
+
+
+_log = fancylogger.getLogger(fname=False)
+
+
+class SlurmJob(object):
+    '''
+    Data type representing a job
+    '''
+    __slots__ = ['jobid', 'state', 'hosts']
+
+    def __init__(self, jobid, jstate, hosts):
+        self.jobid = jobid
+        self.state = jstate
+        self.hosts = hosts
+
+    def __str__(self):
+        return "Jobid %s state %s ehosts %s" % (self.jobid, self.state, self.hosts)
+
+    def __repr__(self):
+        return 'SlurmJob(jobid=%s, state=%s, hosts=%s)' % (self.jobid, self.state, self.hosts)
+
+
+def format_state(jobs):
+    '''Given a list of SlurmJob objects, print them.'''
+    temp = "Id %s State %s Node %s"
+    if len(jobs) == 0:
+        msg = "No jobs found."
+    elif len(jobs) == 1:
+        job = jobs[0]
+        msg = "Found 1 job " + temp % (job.jobid, job.state, job.hosts)
+    else:
+        msg = "Found %s jobs\n" % len(jobs)
+        for j in jobs:
+            msg += "    %s\n" + temp % (j.jobid, j.state, j.hosts)
+    _log.debug("msg %s", msg)
+
+    return msg
+
+
+class Slurm(ResourceManagerScheduler):
+    """Interaction with torque"""
+    def __init__(self, options):
+        super(Slurm, self).__init__(options)
+        self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
+        self.options = options
+        self.log.debug("Provided options %s", options)
+
+        self.vars = {
+            'cwd': 'SLURM_SUBMIT_DIR',
+            'jobid': 'SLURM_JOBID',
+        }
+
+    def submit(self, txt):
+        """Submit the jobscript txt, set self.jobid"""
+        self.log.debug("Going to submit script %s", txt)
+
+        fh, scriptfn = tempfile.mkstemp()
+        f = os.fdopen(fh, 'w')
+        self.log.debug("Writing temp jobscript to %s" % scriptfn)
+        f.write(txt)
+        f.close()
+
+        self.jobid = None  # FIXME replace with submission command
+        self.log.debug("Succesful jobsubmission returned jobid %s", self.jobid)
+
+        os.remove(scriptfn)
+
+    def state(self, jobid=None, job_filter=None):
+        """Return the state of job with id jobid"""
+        if jobid is None:
+            jobid = self.jobid
+
+        state = self.info(jobid, types=['job_state', 'exec_host'], job_filter=job_filter)
+
+        jid = [x['id'] for x in state]
+
+        jstate = [x.get('job_state', None) for x in state]
+
+        def get_uniq_hosts(txt, num=1):
+            """txt host1/cpuid+host2/cpuid
+                - num: number of nodes to return
+            """
+            res = []
+            for h_c in txt.split('+'):
+                h = h_c.split('/')[0]
+                if h in res:
+                    continue
+                res.append(h)
+            return res[:num]
+
+        ehosts = [get_uniq_hosts(x.get('exec_host', '')) for x in state]
+
+        self.log.debug("Jobid  %s jid %s state %s ehosts %s (%s)", jobid, jid, jstate, ehosts, state)
+
+        def _first_or_blank(x):
+            '''Only use first node (don't use [0], job in Q have empty list'''
+            return '' if len(x) == 0 else x[0]
+
+        jobs = [SlurmJob(j, s, h) for (j, s, h) in zip(jid, jstate, map(_first_or_blank, ehosts))]
+        return jobs
+
+    def info(self, jobid, types=None, job_filter=None):
+        """Return jobinfo"""
+
+        res = []
+
+        raise NotImplementedError
+
+        return res
+
+    def remove(self, jobid=None):
+        """Remove the job with id jobid."""
+        if jobid is None:
+            jobid = self.jobid
+
+        raise NotImplementedError
+
+        return False  # FIXME return True if removal worked
+
+    def header(self):
+        """Return the script header that requests the properties.
+           nodes = number of nodes
+           ppn = ppn (-1 = full node)
+           walltime = time in hours (can be float)
+        """
+        nodes = self.options.get('nodes', 50)
+        ppn = self.options.get('ppn', -1)
+        walltime = self.options.get('walltime', 72)
+        mail = self.options.get('mail', [])
+        mail_others = self.options.get('mailothers', [])
+        queue = self.options.get('queue', 'default')
+        partition = self.options.get('partition', 'default')
+        account = self.options.get('account', 'default')
+        reservation = self.options.get('reservation', None)
+
+        self.log.debug("nodes %s, ppn %s, walltime %s, mail %s, mail_others %s, queue %s, partition %s, account %s",
+                       nodes, ppn, walltime, mail, mail_others, queue, partition, account)
+        if nodes is None:
+            nodes = 1
+
+        if ppn is None:
+            ppn = 1
+
+        raise NotImplementedError  # FIXME (stuff below hasn't been cleaned up yet to match Slurm)
+
+        walltime = int(float(walltime) * 60 * 60)  # in hours
+        m, s = divmod(walltime, 60)
+        h, m = divmod(m, 60)
+        # d, h = divmod(h, 24) ## no days
+        # also prints leading 0s (do not insert if x > 0 (eg print 1:0)!
+        # walltimetxt = ":".join(["%02d" % x for x in [ d,h, m, s]]) ## no days
+        walltimetxt = ":".join(["%02d" % x for x in [h, m, s]])
+
+        self.log.debug("Going to generate for nodes %s, ppn %s, walltime %s",
+                       nodes, ppn, walltimetxt)
+
+        self.args = {'resources': {'walltime': walltimetxt,
+                                   'nodes': '%d:ppn=%d' % (nodes, ppn)
+                                   },
+                     }
+
+        if queue:
+            self.args['queue'] = queue
+
+        if partition:
+            self.args['resources']['partition'] = partition
+
+        if account:
+            self.args['account'] = account
+
+        if mail or mail_others:
+            self.args['mail'] = {}
+            if not mail:
+                mail = ['e']
+            self.args['mail']['send'] = ''.join(mail)
+            if mail_others:
+                self.args['mail']['others'] = ','.join(mail_others)
+
+        if reservation:
+            self.args['reservation'] = reservation
+
+        self.log.debug("Create args %s", self.args)
+
+        # # creating the header. Not used in submission!!
+        opts = []
+        for arg in self.args.keys():
+            if arg in ('resources',):
+                for k, v in self.args[arg].items():
+                    opts.append("-l %s=%s" % (k, v))
+            elif arg in ('mail',):
+                opts.append('-m %s' % self.args[arg]['send'])
+                if 'others' in self.args[arg]:
+                    opts.append('-M %s' % self.args[arg]['others'])
+            elif arg in ('queue',):
+                if self.args[arg]:
+                    opts.append('-q %s' % self.args[arg])
+            elif arg in ('account',):
+                if self.args[arg]:
+                    opts.append('-A %s' % self.args[arg])
+            elif arg in ('reservation',):
+                if self.args[arg]:
+                    opts.append('-W x=FLAGS:ADVRES:%s' % self.args[arg])
+            else:
+                self.log.debug("Unknown arg %s. Not adding to args.", arg)
+
+        hdr = ["#SBATCH %s" % o for o in opts]
+        self.log.debug("Created job script header %s", hdr)
+        return hdr
+
+    def get_ppn(self):
+        """Guess the ppn for full node"""
+        raise NotImplementedError

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -107,25 +107,25 @@ class Slurm(ResourceManagerScheduler):
         if jobid is None:
             jobid = self.jobid
 
-        state = self.info(jobid, types=['job_state', 'exec_host'], job_filter=job_filter)
+        state = self.info(jobid, types=['STATE', 'NODELIST'], job_filter=job_filter)
 
         jid = [x['id'] for x in state]
 
-        jstate = [x.get('job_state', None) for x in state]
+        jstate = [x.get('STATE', None) for x in state]
 
         def get_uniq_hosts(txt, num=1):
             """txt host1/cpuid+host2/cpuid
                 - num: number of nodes to return
             """
             res = []
-            for h_c in txt.split('+'):
+            for h_c in txt.split(','):
                 h = h_c.split('/')[0]
                 if h in res:
                     continue
                 res.append(h)
             return res[:num]
 
-        ehosts = [get_uniq_hosts(x.get('exec_host', '')) for x in state]
+        ehosts = [get_uniq_hosts(x.get('NODELIST', '')) for x in state]
 
         self.log.debug("Jobid  %s jid %s state %s ehosts %s (%s)", jobid, jid, jstate, ehosts, state)
 
@@ -177,6 +177,7 @@ class Slurm(ResourceManagerScheduler):
 
         # only known filter is based on job name
         job_name_filter = job_filter.pop('Job_Name', None)
+        print 'job_name_filter: ', job_name_filter
         if job_filter:
             raise NotImplementedError("Unknown job filter keys encountered: %s" % job_filter.keys())
 

--- a/hod/rmscheduler/rm_slurm.py
+++ b/hod/rmscheduler/rm_slurm.py
@@ -109,7 +109,7 @@ class Slurm(ResourceManagerScheduler):
 
         state = self.info(jobid, types=['STATE', 'NODELIST'], job_filter=job_filter)
 
-        jid = [x['id'] for x in state]
+        jid = [x['JOBID'] for x in state]
 
         jstate = [x.get('STATE', None) for x in state]
 
@@ -177,22 +177,19 @@ class Slurm(ResourceManagerScheduler):
 
         # only known filter is based on job name
         job_name_filter = job_filter.pop('Job_Name', None)
-        print 'job_name_filter: ', job_name_filter
         if job_filter:
             raise NotImplementedError("Unknown job filter keys encountered: %s" % job_filter.keys())
 
         # get list of jobs
         jobs = self.list_jobs()
-        import pprint
-        pprint.pprint(jobs)
 
         res = []
         for job in jobs:
-            job_details = {}
             if job_name_filter:
                 regex = re.compile(job_name_filter)
-                if regex.search(job['NAME']):
-                    res.append(job_details)
+                if not regex.search(job['NAME']):
+                    continue
+            res.append(job)
 
         self.log.info("Found job info %s", res)
         return res

--- a/hod/subcommands/destroy.py
+++ b/hod/subcommands/destroy.py
@@ -97,20 +97,20 @@ class DestroySubCommand(SubCommand):
             # try to figure out job state
             job_state = None
 
-            pbs = rm_class(optparser)
-            jobs = pbs.state()
-            pbsjobs = [job for job in jobs if job.jobid == jobid]
-            self.log.debug("Matching jobs for job ID '%s': %s", jobid, pbsjobs)
+            rm = rm_class(optparser)
+            jobs = rm.state()
+            jobs = [job for job in jobs if job.jobid == jobid]
+            self.log.debug("Matching jobs for job ID '%s': %s", jobid, jobs)
 
-            if len(pbsjobs) == 1:
-                job_state = pbsjobs[0].state
+            if len(jobs) == 1:
+                job_state = jobs[0].state
                 print "Job status: %s" % job_state
 
-            elif len(pbsjobs) == 0:
+            elif len(jobs) == 0:
                 print "(job no longer found)"
 
             else:
-                self.report_error("Multiple jobs found with job ID '%s': %s", jobid, pbsjobs)
+                self.report_error("Multiple jobs found with job ID '%s': %s", jobid, jobs)
 
             # request confirmation is case the job is currently running
             if job_state == 'R':
@@ -127,8 +127,8 @@ class DestroySubCommand(SubCommand):
 
             # actually destroy HOD cluster by deleting job and removing cluster info dir and local work dir
             if job_state is not None:
-                # if job was not successfully deleted, pbs.remove will print an error message
-                if pbs.remove(jobid):
+                # if job was not successfully deleted, rm.remove will print an error message
+                if rm.remove(jobid):
                     print "Job with ID %s deleted." % jobid
 
             rm_cluster_localworkdir(label)

--- a/hod/subcommands/listcmd.py
+++ b/hod/subcommands/listcmd.py
@@ -63,10 +63,10 @@ def format_list_rows(cluster_info):
     for info in cluster_info:
         label = info.label if info.label is not None else '<no-label>'
         jobid = info.jobid
-        if info.pbsjob is None:
+        if info.job is None:
             state, hosts = '<job-not-found>', '<none>'
         else:
-            state, hosts = info.pbsjob.state, info.pbsjob.hosts
+            state, hosts = info.job.state, info.job.hosts
         ret.append((label, jobid, state, hosts))
     return ret
 

--- a/test/unit/rmscheduler/test_hodjob.py
+++ b/test/unit/rmscheduler/test_hodjob.py
@@ -102,7 +102,7 @@ class HodRMSchedulerHodjobTestCase(unittest.TestCase):
             'mympirun',
             '--output=$None/hod.output.$None',
             '--hybrid=1',
-            '--variablesprefix=HOD,PBS',
+            '--variablesprefix=HOD,PBS,SLURM,HOME,USER,EBROOTHADOOP,EBROOTHBASE,HADOOP_HOME,JAVA_HOME',
             'python -m hod.local',
             '--hodconf=hod.conf',
         ])

--- a/test/unit/subcommands/test_subcommands_batch.py
+++ b/test/unit/subcommands/test_subcommands_batch.py
@@ -60,45 +60,53 @@ def tmpscript(script):
 class TestBatchSubCommand(unittest.TestCase):
     @pytest.mark.xfail(reason="Requires easybuild environment")
     def test_run_no_args(self):
-        with patch('hod.subcommands.batch.PbsHodJob'):
-            app = BatchSubCommand()
-            self.assertRaises(ValueError, app.run, [])
+        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+            with patch('hod.subcommands.batch.%s' % hodjob_class):
+                app = BatchSubCommand()
+                self.assertRaises(ValueError, app.run, [])
 
     @pytest.mark.xfail(reason="Requires easybuild environment")
     def test_run_with_hodconf_and_no_script(self):
-        with patch('hod.subcommands.batch.PbsHodJob'):
-            app = BatchSubCommand()
-            self.assertEqual(1, app.run(['--hodconf=hod.conf', '--workdir=workdir', '--hod-module=hanythingondemand']))
+        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+            with patch('hod.subcommands.batch.%s' % hodjob_class):
+                app = BatchSubCommand()
+                self.assertEqual(1, app.run(['--hodconf=hod.conf', '--workdir=workdir',
+                                             '--hod-module=hanythingondemand']))
 
     def test_run_fails_with_dist_and_no_script(self):
-        with patch('hod.subcommands.batch.PbsHodJob'):
-            app = BatchSubCommand()
-            self.assertEqual(1, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir', '--hod-module=hanythingondemand']))
+        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+            with patch('hod.subcommands.batch.%s' % hodjob_class):
+                app = BatchSubCommand()
+                self.assertEqual(1, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir',
+                                             '--hod-module=hanythingondemand']))
 
     def test_run_with_hodconf(self):
-        with patch('hod.subcommands.batch.PbsHodJob'):
-            with patch('hod.cluster.mk_cluster_info'):
-                with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
-                    with tmpscript('some-script.sh'):
-                        app = BatchSubCommand()
-                        self.assertEqual(0, app.run(['--hodconf=hod.conf', '--workdir=workdir',
-                                                     '--hod-module=hanythingondemand', '--script=some-script.sh']))
+        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+            with patch('hod.subcommands.batch.%s' % hodjob_class):
+                with patch('hod.cluster.mk_cluster_info'):
+                    with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
+                        with tmpscript('some-script.sh'):
+                            app = BatchSubCommand()
+                            self.assertEqual(0, app.run(['--hodconf=hod.conf', '--workdir=workdir',
+                                                         '--hod-module=hanythingondemand', '--script=some-script.sh']))
 
     def test_run_with_dist(self):
-        with patch('hod.subcommands.batch.PbsHodJob'):
-            with patch('hod.cluster.mk_cluster_info'):
-                with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
-                    with tmpscript('some-script.sh'):
-                        app = BatchSubCommand()
-                        self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir',
-                                                     '--hod-module=hanythingondemand', '--script=some-script.sh']))
+        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+            with patch('hod.subcommands.batch.%s' % hodjob_class):
+                with patch('hod.cluster.mk_cluster_info'):
+                    with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
+                        with tmpscript('some-script.sh'):
+                            app = BatchSubCommand()
+                            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir',
+                                                         '--hod-module=hanythingondemand', '--script=some-script.sh']))
 
     def test_run_fails_with_config_and_dist_arg(self):
-        with patch('hod.subcommands.batch.PbsHodJob'):
-            with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
-                app = BatchSubCommand()
-                self.assertEqual(1, app.run(['--hodconf=hod.conf', '--dist=Hadoop-2.3.0',
-                                             '--hod-module=hanythingondemand', '--workdir=workdir']))
+        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+            with patch('hod.subcommands.batch.%s' % hodjob_class):
+                with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
+                    app = BatchSubCommand()
+                    self.assertEqual(1, app.run(['--hodconf=hod.conf', '--dist=Hadoop-2.3.0',
+                                                 '--hod-module=hanythingondemand', '--workdir=workdir']))
 
     def test_usage(self):
         app = BatchSubCommand()

--- a/test/unit/subcommands/test_subcommands_batch.py
+++ b/test/unit/subcommands/test_subcommands_batch.py
@@ -81,23 +81,25 @@ class TestBatchSubCommand(unittest.TestCase):
                                              '--hod-module=hanythingondemand']))
 
     def test_run_with_hodconf(self):
-        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+        for (rm_backend, hodjob_class) in [('PBS', 'PbsHodJob'), ('Slurm', 'SlurmHodJob')]:
             with patch('hod.subcommands.batch.%s' % hodjob_class):
                 with patch('hod.cluster.mk_cluster_info'):
                     with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
                         with tmpscript('some-script.sh'):
                             app = BatchSubCommand()
-                            self.assertEqual(0, app.run(['--hodconf=hod.conf', '--workdir=workdir',
+                            self.assertEqual(0, app.run(['--rm-backend=%s' % rm_backend,
+                                                         '--hodconf=hod.conf', '--workdir=workdir',
                                                          '--hod-module=hanythingondemand', '--script=some-script.sh']))
 
     def test_run_with_dist(self):
-        for hodjob_class in ['PbsHodJob', 'SlurmHodJob']:
+        for (rm_backend, hodjob_class) in [('PBS', 'PbsHodJob'), ('Slurm', 'SlurmHodJob')]:
             with patch('hod.subcommands.batch.%s' % hodjob_class):
                 with patch('hod.cluster.mk_cluster_info'):
                     with patch('hod.cluster.validate_hodconf_or_dist', return_value=True):
                         with tmpscript('some-script.sh'):
                             app = BatchSubCommand()
-                            self.assertEqual(0, app.run(['--dist=Hadoop-2.3.0', '--workdir=workdir',
+                            self.assertEqual(0, app.run(['--rm-backend=%s' % rm_backend,
+                                                         '--dist=Hadoop-2.3.0', '--workdir=workdir',
                                                          '--hod-module=hanythingondemand', '--script=some-script.sh']))
 
     def test_run_fails_with_config_and_dist_arg(self):

--- a/test/unit/subcommands/test_subcommands_clean.py
+++ b/test/unit/subcommands/test_subcommands_clean.py
@@ -32,6 +32,7 @@ from mock import patch, Mock
 from ..util import capture
 from hod.subcommands.clean import CleanSubCommand
 
+
 class TestCleanSubCommand(unittest.TestCase):
     def test_run(self):
         with patch('hod.cluster.rm_cluster_info'):

--- a/test/unit/test_cluster.py
+++ b/test/unit/test_cluster.py
@@ -113,15 +113,15 @@ class TestCluster(unittest.TestCase):
                 with patch('os.path.exists', return_value=False):
                     self.assertRaises(ValueError, hc._cluster_info, '1234', 'jobid')
 
-    def test_find_pbsjob(self):
+    def test_find_job(self):
         expected = PbsJob('123', 'R', 'host')
-        self.assertEqual(expected.jobid, hc._find_pbsjob('123', [PbsJob('123', 'R', 'host'), PbsJob('abc', 'Q', '')]).jobid)
-        self.assertEqual(None, hc._find_pbsjob('xyz', [PbsJob('123', 'R', 'host'), PbsJob('abc', 'Q', '')]))
+        self.assertEqual(expected.jobid, hc._find_job('123', [PbsJob('123', 'R', 'host'), PbsJob('abc', 'Q', '')]).jobid)
+        self.assertEqual(None, hc._find_job('xyz', [PbsJob('123', 'R', 'host'), PbsJob('abc', 'Q', '')]))
 
-    def test_find_pbsjob_multiple(self):
+    def test_find_job_multiple(self):
         jobs = [PbsJob('123', 'R', 'host1'), PbsJob('abc', 'Q', '')]
-        self.assertEqual(jobs[0], hc._find_pbsjob('123', jobs))
-        self.assertEqual(jobs[1], hc._find_pbsjob('abc', jobs))
+        self.assertEqual(jobs[0], hc._find_job('123', jobs))
+        self.assertEqual(jobs[1], hc._find_job('abc', jobs))
 
     def test_mk_cluster_info_dict(self):
         jobs = [PbsJob('123', 'R', 'host1'), PbsJob('abc', 'Q', '')]


### PR DESCRIPTION
The implementation could probably be a bit cleaner, and this will need some more love to make the tests happy, but these changes seem to be sufficient to make things work more-or-less as expected...

Tested using `Spark-2.4.0-Hadoop-2.9.2` dist and `Python/2.7.15-intel-2018b`:

* running Hadoop WordCount example by submitting a script via `hod batch`
* creating HoD cluster using `hod create`, connecting to it via `hod connect` and running Hadoop WordCount manually